### PR TITLE
🔧 サービス起動・管理の仕組みを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ dist/
 
 # Logs
 *.log
+logs/
+
+# Runtime
+run/
+dump.rdb
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -138,6 +138,53 @@ https://your-tunnel-domain.com/api/webhooks/discord
 | `TUNNEL_TOKEN` | Cloudflare Tunnelトークン（ローカル開発時） | - |
 | `REDIS_URL` | Redis接続URL（デフォルト: `redis://localhost:6379`） | - |
 
+## 起動方法
+
+### 開発（Taskfile）
+
+```bash
+# 全サービス起動（Redis + Cloudflared + Bot）
+task services:up
+
+# 全サービス停止
+task services:down
+
+# 個別起動
+task start          # Bot（ビルド付き）
+task redis:start    # Redis
+task tunnel:start   # Cloudflared
+
+# 個別停止
+task stop
+task redis:stop
+task tunnel:stop
+
+# ログ確認
+task logs           # 全サービス
+task logs:bot       # Botのみ
+```
+
+### 本番（launchd）
+
+```bash
+# サービスのインストール（自動起動有効）
+task services:install
+
+# サービスのアンインストール
+task services:uninstall
+
+# ステータス確認
+launchctl list | grep com.discord-codex
+```
+
+### Docker
+
+```bash
+task docker:up      # コンテナ起動
+task docker:down    # コンテナ停止
+task docker:logs    # ログ確認
+```
+
 ## PR Agent
 
 PRのコメント欄で以下のコマンドを入力すると、AIが自動で処理します。

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,7 +89,6 @@ tasks:
     desc: Stop Redis
     cmds:
       - kill "$(cat run/redis.pid)" 2>/dev/null || true
-      - pkill -f 'redis-server' 2>/dev/null || true
       - rm -f run/redis.pid
 
   tunnel:start:
@@ -101,7 +100,6 @@ tasks:
     desc: Stop Cloudflared tunnel
     cmds:
       - kill "$(cat run/cloudflared.pid)" 2>/dev/null || true
-      - pkill -f 'cloudflared' 2>/dev/null || true
       - rm -f run/cloudflared.pid
 
   services:up:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,3 +61,86 @@ tasks:
     desc: View Docker container logs
     cmds:
       - docker compose logs -f
+
+  start:
+    desc: Build and start the bot (development)
+    cmds:
+      - bash scripts/start-bot.sh --dev
+
+  stop:
+    desc: Stop the bot
+    cmds:
+      - kill "$(cat run/bot.pid)" 2>/dev/null || true
+      - pkill -f 'node dist/index.js' 2>/dev/null || true
+      - rm -f run/bot.pid
+
+  restart:
+    desc: Restart the bot
+    cmds:
+      - task: stop
+      - task: start
+
+  redis:start:
+    desc: Start Redis (development)
+    cmds:
+      - bash scripts/start-redis.sh --dev
+
+  redis:stop:
+    desc: Stop Redis
+    cmds:
+      - kill "$(cat run/redis.pid)" 2>/dev/null || true
+      - pkill -f 'redis-server' 2>/dev/null || true
+      - rm -f run/redis.pid
+
+  tunnel:start:
+    desc: Start Cloudflared tunnel (development)
+    cmds:
+      - bash scripts/start-cloudflared.sh --dev
+
+  tunnel:stop:
+    desc: Stop Cloudflared tunnel
+    cmds:
+      - kill "$(cat run/cloudflared.pid)" 2>/dev/null || true
+      - pkill -f 'cloudflared' 2>/dev/null || true
+      - rm -f run/cloudflared.pid
+
+  services:up:
+    desc: Start all services (development)
+    cmds:
+      - task: redis:start
+      - task: tunnel:start
+      - task: start
+
+  services:down:
+    desc: Stop all services
+    cmds:
+      - task: stop
+      - task: tunnel:stop
+      - task: redis:stop
+
+  logs:
+    desc: Tail all service logs
+    cmds:
+      - tail -f logs/bot.log logs/redis.log logs/cloudflared.log
+
+  logs:bot:
+    desc: Tail bot logs
+    cmds:
+      - tail -f logs/bot.log
+
+  services:install:
+    desc: Install launchd plists (production)
+    cmds:
+      - mkdir -p ~/Library/LaunchAgents
+      - for f in scripts/com.discord-codex-*.plist; do sed "s|__PROJECT_ROOT__|$(pwd)|g" "$f" > ~/Library/LaunchAgents/"$(basename "$f")"; done
+      - launchctl load ~/Library/LaunchAgents/com.discord-codex-bot.plist
+      - launchctl load ~/Library/LaunchAgents/com.discord-codex-redis.plist
+      - launchctl load ~/Library/LaunchAgents/com.discord-codex-cloudflared.plist
+
+  services:uninstall:
+    desc: Uninstall launchd services (production)
+    cmds:
+      - launchctl unload ~/Library/LaunchAgents/com.discord-codex-bot.plist 2>/dev/null || true
+      - launchctl unload ~/Library/LaunchAgents/com.discord-codex-redis.plist 2>/dev/null || true
+      - launchctl unload ~/Library/LaunchAgents/com.discord-codex-cloudflared.plist 2>/dev/null || true
+      - rm -f ~/Library/LaunchAgents/com.discord-codex-*.plist

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "rm -rf dist",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "start": "node dist/index.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/com.discord-codex-bot.plist
+++ b/scripts/com.discord-codex-bot.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.discord-codex-bot</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__PROJECT_ROOT__/scripts/start-bot.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/logs/bot.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/logs/bot-error.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/com.discord-codex-cloudflared.plist
+++ b/scripts/com.discord-codex-cloudflared.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.discord-codex-cloudflared</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__PROJECT_ROOT__/scripts/start-cloudflared.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/logs/cloudflared.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/logs/cloudflared-error.log</string>
+</dict>
+</plist>

--- a/scripts/com.discord-codex-redis.plist
+++ b/scripts/com.discord-codex-redis.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.discord-codex-redis</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__PROJECT_ROOT__/scripts/start-redis.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__PROJECT_ROOT__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__PROJECT_ROOT__/logs/redis.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__PROJECT_ROOT__/logs/redis-error.log</string>
+</dict>
+</plist>

--- a/scripts/start-bot.sh
+++ b/scripts/start-bot.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_MODE=false
+
+if [ "${1:-}" = "--dev" ]; then
+  DEV_MODE=true
+fi
+
+# Load Nix environment
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
+# Load .env
+if [ -f "$PROJECT_ROOT/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/.env"
+  set +a
+fi
+
+mkdir -p "$PROJECT_ROOT/logs"
+
+cd "$PROJECT_ROOT"
+
+if [ "$DEV_MODE" = true ]; then
+  mkdir -p "$PROJECT_ROOT/run"
+  nohup nix develop --command bash -c "pnpm build && pnpm start" > logs/bot.log 2>&1 &
+  echo $! > "$PROJECT_ROOT/run/bot.pid"
+  echo "Bot started with PID $(cat "$PROJECT_ROOT/run/bot.pid")"
+else
+  nix develop --command pnpm start
+fi

--- a/scripts/start-bot.sh
+++ b/scripts/start-bot.sh
@@ -27,7 +27,7 @@ cd "$PROJECT_ROOT"
 
 if [ "$DEV_MODE" = true ]; then
   mkdir -p "$PROJECT_ROOT/run"
-  nohup nix develop --command bash -c "pnpm build && pnpm start" > logs/bot.log 2>&1 &
+  nohup nix develop --command bash -c "pnpm build && exec pnpm start" > logs/bot.log 2>&1 &
   echo $! > "$PROJECT_ROOT/run/bot.pid"
   echo "Bot started with PID $(cat "$PROJECT_ROOT/run/bot.pid")"
 else

--- a/scripts/start-cloudflared.sh
+++ b/scripts/start-cloudflared.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_MODE=false
+
+if [ "${1:-}" = "--dev" ]; then
+  DEV_MODE=true
+fi
+
+# Load .env
+if [ -f "$PROJECT_ROOT/.env" ]; then
+  set -a
+  source "$PROJECT_ROOT/.env"
+  set +a
+fi
+
+if [ -z "${TUNNEL_TOKEN:-}" ]; then
+  echo "TUNNEL_TOKEN is not set" >&2
+  exit 1
+fi
+
+command -v cloudflared >/dev/null 2>&1 || {
+  echo "cloudflared not found in PATH" >&2
+  exit 1
+}
+
+mkdir -p "$PROJECT_ROOT/logs"
+
+cd "$PROJECT_ROOT"
+
+if [ "$DEV_MODE" = true ]; then
+  mkdir -p "$PROJECT_ROOT/run"
+  nohup cloudflared tunnel run --token "$TUNNEL_TOKEN" > logs/cloudflared.log 2>&1 &
+  echo $! > "$PROJECT_ROOT/run/cloudflared.pid"
+  echo "Cloudflared started with PID $(cat "$PROJECT_ROOT/run/cloudflared.pid")"
+else
+  cloudflared tunnel run --token "$TUNNEL_TOKEN"
+fi

--- a/scripts/start-redis.sh
+++ b/scripts/start-redis.sh
@@ -20,9 +20,8 @@ cd "$PROJECT_ROOT"
 
 if [ "$DEV_MODE" = true ]; then
   mkdir -p "$PROJECT_ROOT/run"
-  nohup nix develop --command redis-server > logs/redis.log 2>&1 &
-  echo $! > "$PROJECT_ROOT/run/redis.pid"
-  echo "Redis started with PID $(cat "$PROJECT_ROOT/run/redis.pid")"
+  nohup nix develop --command redis-server --pidfile "$PROJECT_ROOT/run/redis.pid" > logs/redis.log 2>&1 &
+  echo "Redis starting (PID file: $PROJECT_ROOT/run/redis.pid)"
 else
   nix develop --command redis-server
 fi

--- a/scripts/start-redis.sh
+++ b/scripts/start-redis.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEV_MODE=false
+
+if [ "${1:-}" = "--dev" ]; then
+  DEV_MODE=true
+fi
+
+# Load Nix environment
+if [ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
+mkdir -p "$PROJECT_ROOT/logs"
+
+cd "$PROJECT_ROOT"
+
+if [ "$DEV_MODE" = true ]; then
+  mkdir -p "$PROJECT_ROOT/run"
+  nohup nix develop --command redis-server > logs/redis.log 2>&1 &
+  echo $! > "$PROJECT_ROOT/run/redis.pid"
+  echo "Redis started with PID $(cat "$PROJECT_ROOT/run/redis.pid")"
+else
+  nix develop --command redis-server
+fi

--- a/src/ai/client/codex-exec.client.ts
+++ b/src/ai/client/codex-exec.client.ts
@@ -1,4 +1,4 @@
-import { Codex, type Usage, type ThreadOptions } from "@openai/codex-sdk";
+import { Codex, type ThreadOptions, type Usage } from "@openai/codex-sdk";
 import { ExternalServiceError } from "@/shared/types/errors";
 
 const DEFAULT_TIMEOUT_MS = 600_000;


### PR DESCRIPTION
# チケット

close #17

# 概要

Bot、Redis、Cloudflaredの各サービスを統合的に起動・停止・管理できる仕組みを追加しました。

### 変更内容

- **起動スクリプト**: `scripts/` にBot・Redis・Cloudflaredそれぞれの起動スクリプトを追加
- **launchd plist**: 本番環境向けにmacOSのlaunchdサービス定義ファイルを追加
- **Taskfileタスク**: サービスの起動・停止・再起動・ログ確認・launchdのインストール等のタスクを追加
- **package.json**: `pnpm start` スクリプトを追加
- **.gitignore**: ログ・PID・Redisダンプファイルの除外パターンを追加
- **README**: 開発・本番・Dockerそれぞれの起動方法を追記

# その他

resolves #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)