### PR TITLE
インフラストラクチャ層にGitHubクライアントとワークスペースマネージャーを追加

### DIFF
--- a/src/infrastructure/github/github.client.test.ts
+++ b/src/infrastructure/github/github.client.test.ts
@@ -1,0 +1,357 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalServiceError, NotFoundError } from "@/shared/types/errors";
+import { GitHubClient } from "./github.client";
+
+const { mockExecCommand } = vi.hoisted(() => ({
+  mockExecCommand: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/exec", () => ({
+  execCommand: mockExecCommand,
+}));
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe("GitHubClient getIssue mapping", () => {
+  let client: GitHubClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new GitHubClient();
+  });
+
+  it("returns IssueInfo on successful gh api call", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 42,
+        title: "Bug fix",
+        body: "Description here",
+        state: "open",
+        labels: [{ name: "bug" }, { name: "priority" }],
+        assignees: [{ login: "dev1" }],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-02T00:00:00Z",
+      }),
+      stderr: "",
+    });
+
+    const result = await client.getIssue("owner", "repo", 42);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.number).toBe(42);
+      expect(result.value.title).toBe("Bug fix");
+      expect(result.value.state).toBe("open");
+      expect(result.value.labels).toEqual(["bug", "priority"]);
+      expect(result.value.assignees).toEqual(["dev1"]);
+    }
+  });
+
+  it("maps null body correctly", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 1,
+        title: "No body",
+        body: null,
+        state: "open",
+        labels: [],
+        assignees: [],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
+      stderr: "",
+    });
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.body).toBeNull();
+    }
+  });
+
+  it("maps undefined body to null", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 1,
+        title: "No body",
+        state: "open",
+        labels: [],
+        assignees: [],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
+      stderr: "",
+    });
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.body).toBeNull();
+    }
+  });
+
+  it("calls gh api with correct arguments", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 42,
+        title: "Test",
+        body: null,
+        state: "open",
+        labels: [],
+        assignees: [],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
+      stderr: "",
+    });
+
+    await client.getIssue("myOwner", "myRepo", 42);
+
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/myOwner/myRepo/issues/42"],
+      { timeout: 30_000 },
+    );
+  });
+
+  it("maps closed state correctly", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        number: 5,
+        title: "Closed issue",
+        body: "Resolved",
+        state: "closed",
+        labels: [],
+        assignees: [],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-03T00:00:00Z",
+      }),
+      stderr: "",
+    });
+
+    const result = await client.getIssue("owner", "repo", 5);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.state).toBe("closed");
+    }
+  });
+});
+
+describe("GitHubClient getIssue errors", () => {
+  let client: GitHubClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new GitHubClient();
+  });
+
+  it("returns NotFoundError when issue does not exist", async () => {
+    const error = new Error("Command failed");
+    (error as unknown as { stderr: string }).stderr = '{"message":"Not Found"}';
+    mockExecCommand.mockRejectedValue(error);
+
+    const result = await client.getIssue("owner", "repo", 999);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    }
+  });
+
+  it("returns ExternalServiceError on other failures", async () => {
+    mockExecCommand.mockRejectedValue(new Error("authentication required"));
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("authentication required");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown", async () => {
+    mockExecCommand.mockRejectedValue("string error");
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("string error");
+    }
+  });
+
+  it("returns NotFoundError when stderr is plain text containing 'Not Found'", async () => {
+    const error = new Error("Command failed");
+    (error as unknown as { stderr: string }).stderr =
+      "error: Not Found in response";
+    mockExecCommand.mockRejectedValue(error);
+
+    const result = await client.getIssue("owner", "repo", 999);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(NotFoundError);
+    }
+  });
+
+  it("returns ExternalServiceError when stderr JSON has different message", async () => {
+    const error = new Error("Command failed");
+    (error as unknown as { stderr: string }).stderr =
+      '{"message":"Bad Request"}';
+    mockExecCommand.mockRejectedValue(error);
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+    }
+  });
+
+  it("returns ExternalServiceError when error has no stderr property", async () => {
+    mockExecCommand.mockRejectedValue(new Error("network error"));
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+    }
+  });
+
+  it("returns ExternalServiceError when stderr is empty string", async () => {
+    const error = new Error("Command failed");
+    (error as unknown as { stderr: string }).stderr = "";
+    mockExecCommand.mockRejectedValue(error);
+
+    const result = await client.getIssue("owner", "repo", 1);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+    }
+  });
+});
+
+describe("GitHubClient createPullRequest success", () => {
+  let client: GitHubClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new GitHubClient();
+  });
+
+  it("returns CreatePRResult on successful gh api call", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        html_url: "https://github.com/owner/repo/pull/10",
+        number: 10,
+      }),
+      stderr: "",
+    });
+
+    const result = await client.createPullRequest("owner", "repo", {
+      title: "Fix bug",
+      body: "PR description",
+      head: "fix-branch",
+      base: "main",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.url).toBe("https://github.com/owner/repo/pull/10");
+      expect(result.value.number).toBe(10);
+    }
+  });
+
+  it("calls gh api with correct arguments", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: JSON.stringify({
+        html_url: "https://github.com/owner/repo/pull/10",
+        number: 10,
+      }),
+      stderr: "",
+    });
+
+    await client.createPullRequest("owner", "repo", {
+      title: "Fix bug",
+      body: "PR description",
+      head: "fix-branch",
+      base: "main",
+    });
+
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "gh",
+      [
+        "api",
+        "repos/owner/repo/pulls",
+        "--method",
+        "POST",
+        "--field",
+        "title=Fix bug",
+        "--field",
+        "body=PR description",
+        "--field",
+        "head=fix-branch",
+        "--field",
+        "base=main",
+      ],
+      { timeout: 30_000 },
+    );
+  });
+});
+
+describe("GitHubClient createPullRequest errors", () => {
+  let client: GitHubClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new GitHubClient();
+  });
+
+  it("returns ExternalServiceError on failure", async () => {
+    mockExecCommand.mockRejectedValue(new Error("validation failed"));
+
+    const result = await client.createPullRequest("owner", "repo", {
+      title: "Fix",
+      body: "Desc",
+      head: "branch",
+      base: "main",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("validation failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown", async () => {
+    mockExecCommand.mockRejectedValue("network failure");
+
+    const result = await client.createPullRequest("owner", "repo", {
+      title: "Fix",
+      body: "Desc",
+      head: "branch",
+      base: "main",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("network failure");
+    }
+  });
+});

--- a/src/infrastructure/github/github.client.test.ts
+++ b/src/infrastructure/github/github.client.test.ts
@@ -301,7 +301,7 @@ describe("GitHubClient createPullRequest success", () => {
         "POST",
         "--field",
         "title=Fix bug",
-        "--field",
+        "--raw-field",
         "body=PR description",
         "--field",
         "head=fix-branch",

--- a/src/infrastructure/github/github.client.ts
+++ b/src/infrastructure/github/github.client.ts
@@ -1,0 +1,146 @@
+import { ExternalServiceError, NotFoundError } from "@/shared/types/errors";
+import { err, ok, type Result } from "@/shared/types/result";
+import { execCommand } from "@/shared/utils/exec";
+import { getLogger } from "@/shared/utils/logger";
+
+const GH_TIMEOUT_MS = 30_000;
+
+export interface IssueInfo {
+  number: number;
+  title: string;
+  body: string | null;
+  owner: string;
+  repo: string;
+  state: "open" | "closed";
+  labels: string[];
+  assignees: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePROptions {
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+}
+
+export interface CreatePRResult {
+  url: string;
+  number: number;
+}
+
+export class GitHubClient {
+  async getIssue(
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): Promise<Result<IssueInfo>> {
+    const log = getLogger();
+
+    try {
+      const { stdout } = await execCommand(
+        "gh",
+        ["api", `repos/${owner}/${repo}/issues/${issueNumber}`],
+        { timeout: GH_TIMEOUT_MS },
+      );
+
+      const data = JSON.parse(stdout);
+      return ok({
+        number: data.number,
+        title: data.title,
+        body: data.body ?? null,
+        owner,
+        repo,
+        state: data.state,
+        labels: data.labels.map((l: { name: string }) => l.name),
+        assignees: data.assignees.map((a: { login: string }) => a.login),
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      });
+    } catch (e) {
+      if (GitHubClient.isNotFound(e)) {
+        return err(new NotFoundError(`Issue ${owner}/${repo}#${issueNumber}`));
+      }
+
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          owner,
+          repo,
+          issueNumber,
+        },
+        "Failed to fetch issue via gh api",
+      );
+      return err(
+        new ExternalServiceError(
+          "GitHub",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  async createPullRequest(
+    owner: string,
+    repo: string,
+    options: CreatePROptions,
+  ): Promise<Result<CreatePRResult>> {
+    const log = getLogger();
+
+    try {
+      const { stdout } = await execCommand(
+        "gh",
+        [
+          "api",
+          `repos/${owner}/${repo}/pulls`,
+          "--method",
+          "POST",
+          "--field",
+          `title=${options.title}`,
+          "--field",
+          `body=${options.body}`,
+          "--field",
+          `head=${options.head}`,
+          "--field",
+          `base=${options.base}`,
+        ],
+        { timeout: GH_TIMEOUT_MS },
+      );
+
+      const data = JSON.parse(stdout);
+      return ok({ url: data.html_url, number: data.number });
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          owner,
+          repo,
+          head: options.head,
+          base: options.base,
+        },
+        "Failed to create pull request via gh api",
+      );
+      return err(
+        new ExternalServiceError(
+          "GitHub",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+  private static isNotFound(e: unknown): boolean {
+    if (e && typeof e === "object" && "stderr" in e) {
+      const stderr = (e as { stderr?: string }).stderr;
+      if (!stderr) return false;
+
+      try {
+        const parsed = JSON.parse(stderr);
+        return parsed.message === "Not Found";
+      } catch {
+        return stderr.includes("Not Found");
+      }
+    }
+    return false;
+  }
+}

--- a/src/infrastructure/github/github.client.ts
+++ b/src/infrastructure/github/github.client.ts
@@ -98,7 +98,7 @@ export class GitHubClient {
           "POST",
           "--field",
           `title=${options.title}`,
-          "--field",
+          "--raw-field",
           `body=${options.body}`,
           "--field",
           `head=${options.head}`,

--- a/src/infrastructure/workspace/workspace.manager.test.ts
+++ b/src/infrastructure/workspace/workspace.manager.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { WorkspaceManager } from "./workspace.manager";
+
+const { mockExecCommand, mockExistsSync } = vi.hoisted(() => ({
+  mockExecCommand: vi.fn(),
+  mockExistsSync: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/exec", () => ({
+  execCommand: mockExecCommand,
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+}));
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const WORKSPACE_ROOT = "/workspace";
+
+describe("WorkspaceManager ensureClone", () => {
+  let manager: WorkspaceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorkspaceManager(WORKSPACE_ROOT);
+  });
+
+  it("clones repository when directory does not exist", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecCommand.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await manager.ensureClone(
+      "https://github.com/owner/repo.git",
+      "repos/repo",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "git",
+      ["clone", "https://github.com/owner/repo.git", "/workspace/repos/repo"],
+      { timeout: 60_000 },
+    );
+  });
+
+  it("skips clone when directory already exists", async () => {
+    mockExistsSync.mockReturnValue(true);
+
+    const result = await manager.ensureClone(
+      "https://github.com/owner/repo.git",
+      "repos/repo",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(mockExecCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns ExternalServiceError on clone failure", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecCommand.mockRejectedValue(new Error("clone failed"));
+
+    const result = await manager.ensureClone(
+      "https://github.com/owner/repo.git",
+      "repos/repo",
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("clone failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown during clone", async () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecCommand.mockRejectedValue("timeout");
+
+    const result = await manager.ensureClone(
+      "https://github.com/owner/repo.git",
+      "repos/repo",
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("timeout");
+    }
+  });
+});
+
+describe("WorkspaceManager syncMain", () => {
+  let manager: WorkspaceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorkspaceManager(WORKSPACE_ROOT);
+  });
+
+  it("checks out main and pulls latest", async () => {
+    mockExecCommand.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await manager.syncMain("repos/repo");
+
+    expect(result.ok).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledTimes(2);
+    expect(mockExecCommand).toHaveBeenCalledWith("git", ["checkout", "main"], {
+      cwd: "/workspace/repos/repo",
+      timeout: 60_000,
+    });
+    expect(mockExecCommand).toHaveBeenCalledWith("git", ["pull"], {
+      cwd: "/workspace/repos/repo",
+      timeout: 60_000,
+    });
+  });
+
+  it("returns ExternalServiceError on checkout failure", async () => {
+    mockExecCommand.mockRejectedValueOnce(new Error("checkout failed"));
+
+    const result = await manager.syncMain("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("checkout failed");
+    }
+  });
+
+  it("returns ExternalServiceError on pull failure", async () => {
+    mockExecCommand
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockRejectedValueOnce(new Error("pull failed"));
+
+    const result = await manager.syncMain("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("pull failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown during sync", async () => {
+    mockExecCommand.mockRejectedValue("connection lost");
+
+    const result = await manager.syncMain("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("connection lost");
+    }
+  });
+});
+
+describe("WorkspaceManager createBranch", () => {
+  let manager: WorkspaceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorkspaceManager(WORKSPACE_ROOT);
+  });
+
+  it("creates a new feature branch", async () => {
+    mockExecCommand.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await manager.createBranch("repos/repo", "feature/123");
+
+    expect(result.ok).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "git",
+      ["checkout", "-b", "feature/123"],
+      { cwd: "/workspace/repos/repo", timeout: 60_000 },
+    );
+  });
+
+  it("returns ExternalServiceError on failure", async () => {
+    mockExecCommand.mockRejectedValue(new Error("branch creation failed"));
+
+    const result = await manager.createBranch("repos/repo", "feature/123");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("branch creation failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown", async () => {
+    mockExecCommand.mockRejectedValue("signal abort");
+
+    const result = await manager.createBranch("repos/repo", "feature/123");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("signal abort");
+    }
+  });
+});
+
+describe("WorkspaceManager getDiff", () => {
+  let manager: WorkspaceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorkspaceManager(WORKSPACE_ROOT);
+  });
+
+  it("returns diff content", async () => {
+    mockExecCommand.mockResolvedValue({
+      stdout: "diff --git a/file.ts b/file.ts\n+new line",
+      stderr: "",
+    });
+
+    const result = await manager.getDiff("repos/repo");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("diff --git");
+    }
+  });
+
+  it("returns empty string when no diff", async () => {
+    mockExecCommand.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await manager.getDiff("repos/repo");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("");
+    }
+  });
+
+  it("returns ExternalServiceError on failure", async () => {
+    mockExecCommand.mockRejectedValue(new Error("diff failed"));
+
+    const result = await manager.getDiff("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("diff failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown", async () => {
+    mockExecCommand.mockRejectedValue("io error");
+
+    const result = await manager.getDiff("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("io error");
+    }
+  });
+});
+
+describe("WorkspaceManager discardChanges", () => {
+  let manager: WorkspaceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new WorkspaceManager(WORKSPACE_ROOT);
+  });
+
+  it("discards working directory changes", async () => {
+    mockExecCommand.mockResolvedValue({ stdout: "", stderr: "" });
+
+    const result = await manager.discardChanges("repos/repo");
+
+    expect(result.ok).toBe(true);
+    expect(mockExecCommand).toHaveBeenCalledWith(
+      "git",
+      ["checkout", "--", "."],
+      { cwd: "/workspace/repos/repo", timeout: 60_000 },
+    );
+  });
+
+  it("returns ExternalServiceError on failure", async () => {
+    mockExecCommand.mockRejectedValue(new Error("discard failed"));
+
+    const result = await manager.discardChanges("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("discard failed");
+    }
+  });
+
+  it("returns ExternalServiceError when non-Error is thrown", async () => {
+    mockExecCommand.mockRejectedValue("unknown crash");
+
+    const result = await manager.discardChanges("repos/repo");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(ExternalServiceError);
+      expect(result.error.message).toContain("unknown crash");
+    }
+  });
+});

--- a/src/infrastructure/workspace/workspace.manager.ts
+++ b/src/infrastructure/workspace/workspace.manager.ts
@@ -1,0 +1,164 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok, type Result } from "@/shared/types/result";
+import { execCommand } from "@/shared/utils/exec";
+import { getLogger } from "@/shared/utils/logger";
+
+const GIT_TIMEOUT_MS = 60_000;
+
+export class WorkspaceManager {
+  constructor(private readonly workspaceRoot: string) {}
+
+  async ensureClone(repoUrl: string, targetDir: string): Promise<Result<void>> {
+    const log = getLogger();
+    const fullPath = join(this.workspaceRoot, targetDir);
+
+    if (existsSync(fullPath)) {
+      log.debug({ targetDir: fullPath }, "Repository already cloned, skipping");
+      return ok(undefined);
+    }
+
+    try {
+      await execCommand("git", ["clone", repoUrl, fullPath], {
+        timeout: GIT_TIMEOUT_MS,
+      });
+      log.info({ repoUrl, targetDir: fullPath }, "Repository cloned");
+      return ok(undefined);
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          repoUrl,
+          targetDir: fullPath,
+        },
+        "Failed to clone repository",
+      );
+      return err(
+        new ExternalServiceError(
+          "Git",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  async syncMain(targetDir: string): Promise<Result<void>> {
+    const log = getLogger();
+    const fullPath = join(this.workspaceRoot, targetDir);
+
+    try {
+      await execCommand("git", ["checkout", "main"], {
+        cwd: fullPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      await execCommand("git", ["pull"], {
+        cwd: fullPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      log.info({ targetDir: fullPath }, "Synced main branch");
+      return ok(undefined);
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          targetDir: fullPath,
+        },
+        "Failed to sync main branch",
+      );
+      return err(
+        new ExternalServiceError(
+          "Git",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  async createBranch(
+    targetDir: string,
+    branchName: string,
+  ): Promise<Result<void>> {
+    const log = getLogger();
+    const fullPath = join(this.workspaceRoot, targetDir);
+
+    try {
+      await execCommand("git", ["checkout", "-b", branchName], {
+        cwd: fullPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      log.info({ targetDir: fullPath, branchName }, "Created feature branch");
+      return ok(undefined);
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          targetDir: fullPath,
+          branchName,
+        },
+        "Failed to create branch",
+      );
+      return err(
+        new ExternalServiceError(
+          "Git",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  async getDiff(targetDir: string): Promise<Result<string>> {
+    const log = getLogger();
+    const fullPath = join(this.workspaceRoot, targetDir);
+
+    try {
+      const { stdout } = await execCommand("git", ["diff"], {
+        cwd: fullPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      return ok(stdout);
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          targetDir: fullPath,
+        },
+        "Failed to get diff",
+      );
+      return err(
+        new ExternalServiceError(
+          "Git",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+
+  async discardChanges(targetDir: string): Promise<Result<void>> {
+    const log = getLogger();
+    const fullPath = join(this.workspaceRoot, targetDir);
+
+    try {
+      await execCommand("git", ["checkout", "--", "."], {
+        cwd: fullPath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      log.info({ targetDir: fullPath }, "Discarded working directory changes");
+      return ok(undefined);
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          targetDir: fullPath,
+        },
+        "Failed to discard changes",
+      );
+      return err(
+        new ExternalServiceError(
+          "Git",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+}

--- a/src/shared/utils/exec.test.ts
+++ b/src/shared/utils/exec.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { execCommand } from "./exec";
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+}));
+
+describe("execCommand", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns stdout and stderr on successful execution", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(null, { stdout: "hello world", stderr: "" });
+    });
+
+    const result = await execCommand("echo", ["hello", "world"]);
+
+    expect(result).toEqual({ stdout: "hello world", stderr: "" });
+  });
+
+  it("passes cwd option to child process", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, opts, cb) => {
+      expect(opts.cwd).toBe("/tmp/project");
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    await execCommand("ls", [], { cwd: "/tmp/project" });
+  });
+
+  it("passes timeout option to child process", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, opts, cb) => {
+      expect(opts.timeout).toBe(5000);
+      cb(null, { stdout: "", stderr: "" });
+    });
+
+    await execCommand("ls", [], { timeout: 5000 });
+  });
+
+  it("throws on command failure", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(new Error("Command failed with exit code 1"));
+    });
+
+    await expect(execCommand("false", [])).rejects.toThrow(
+      "Command failed with exit code 1",
+    );
+  });
+
+  it("works without options (defaults)", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, opts, cb) => {
+      expect(opts.cwd).toBeUndefined();
+      expect(opts.timeout).toBeUndefined();
+      cb(null, { stdout: "ok", stderr: "" });
+    });
+
+    const result = await execCommand("echo", ["test"]);
+
+    expect(result.stdout).toBe("ok");
+  });
+
+  it("passes both cwd and timeout options together", async () => {
+    mockExecFile.mockImplementation((_cmd, _args, opts, cb) => {
+      expect(opts.cwd).toBe("/tmp/project");
+      expect(opts.timeout).toBe(10_000);
+      cb(null, { stdout: "done", stderr: "" });
+    });
+
+    const result = await execCommand("ls", [], {
+      cwd: "/tmp/project",
+      timeout: 10_000,
+    });
+
+    expect(result.stdout).toBe("done");
+  });
+});

--- a/src/shared/utils/exec.ts
+++ b/src/shared/utils/exec.ts
@@ -1,0 +1,21 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCb);
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+export async function execCommand(
+  command: string,
+  args: string[],
+  options?: { cwd?: string; timeout?: number },
+): Promise<ExecResult> {
+  return (await execFileAsync(command, args, {
+    cwd: options?.cwd,
+    timeout: options?.timeout,
+    encoding: "utf-8",
+  })) as ExecResult;
+}


### PR DESCRIPTION
# チケット

resolves #11

# 概要

Issue #11 の対応として、インフラストラクチャ層に外部サービス連携のための基盤を追加しました。

### 追加内容

- **execCommandユーティリティ** (`src/shared/utils/exec.ts`)
  - `node:child_process` の `execFile` をPromise化した汎用コマンド実行ユーティリティ
  - `cwd` / `timeout` オプションに対応

- **GitHubClient** (`src/infrastructure/github/github.client.ts`)
  - `gh` CLI経由でIssue取得・PR作成を行うクライアント
  - `getIssue()`: Issue情報の取得（NotFoundError / ExternalServiceErrorのハンドリング付き）
  - `createPullRequest()`: PR作成

- **WorkspaceManager** (`src/infrastructure/workspace/workspace.manager.ts`)
  - Gitワークスペースの操作を管理するクラス
  - `ensureClone()`: リポジトリのクローン（既存時はスキップ）
  - `syncMain()`: mainブランチのチェックアウト + pull
  - `createBranch()`: フィーチャーブランチの作成
  - `getDiff()`: 差分の取得
  - `discardChanges()`: 作業ディレクトリの変更破棄

- 各モジュールに対するテストを同梱しています。

# その他

Biomeのlint警告（`noExcessiveLinesPerFunction`）がテストファイルのdescribeブロックで出ていますが、テストの可読性を優先してそのままとしています。