### PR TITLE
✨ developプロンプトテンプレートとバイトベース切り詰めユーティリティを追加 #13

### DIFF
--- a/src/ai/prompts/templates/develop-commit.test.ts
+++ b/src/ai/prompts/templates/develop-commit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildDevelopCommitPrompt } from "./develop-commit";
+
+describe("buildDevelopCommitPrompt", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "コンテキスト変数がプロンプトに含まれる", () => {
+    const result = buildDevelopCommitPrompt({
+      diff: "+ function hello() { return 'hi'; }",
+      issueNumber: 42,
+      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
+      issueTitle: "新機能を追加",
+    });
+    expect(result).toContain("+ function hello() { return 'hi'; }");
+    expect(result).toContain("#42");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("新機能を追加");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "期待される指示が生成される", () => {
+    const result = buildDevelopCommitPrompt({
+      diff: "test diff",
+      issueNumber: 1,
+      issueTitle: "test",
+    });
+    expect(result).toContain("git add -A");
+    expect(result).toContain("git commit -m");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空の diff を処理する", () => {
+    const result = buildDevelopCommitPrompt({
+      diff: "",
+      issueNumber: 1,
+      issueTitle: "test",
+    });
+    expect(result).toContain("git add -A");
+  });
+});

--- a/src/ai/prompts/templates/develop-commit.ts
+++ b/src/ai/prompts/templates/develop-commit.ts
@@ -1,0 +1,32 @@
+export interface DevelopCommitContext {
+  diff: string;
+  issueNumber: number;
+  issueTitle: string;
+}
+
+export function buildDevelopCommitPrompt(
+  context: DevelopCommitContext,
+): string {
+  return [
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "以下の実装差分に基づいて、コミットメッセージを生成しコミットしてください。",
+    "",
+    "## Issue情報",
+    `- Issue #${context.issueNumber}: ${context.issueTitle}`,
+    "",
+    "## 実装差分",
+    context.diff,
+    "",
+    "## 指示",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- コミットメッセージは日本語で記述してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- コミットメッセージの1行目は簡潔に変更概要を記載してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 必要に応じて2行目以降に詳細を記載してください",
+    "- 以下のコマンドでコミットしてください:",
+    "  git add -A",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    '  git commit -m "生成したコミットメッセージ"',
+  ].join("\n");
+}

--- a/src/ai/prompts/templates/develop-impl.test.ts
+++ b/src/ai/prompts/templates/develop-impl.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildDevelopImplPrompt } from "./develop-impl";
+
+describe("buildDevelopImplPrompt", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "コンテキスト変数がプロンプトに含まれる", () => {
+    const result = buildDevelopImplPrompt({
+      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
+      planOutput: "ステップ1: ファイルを作成する",
+      repo: "owner/repo",
+      branch: "feature/1",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("ステップ1: ファイルを作成する");
+    expect(result).toContain("owner/repo");
+    expect(result).toContain("feature/1");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "期待される指示が生成される", () => {
+    const result = buildDevelopImplPrompt({
+      planOutput: "test",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("計画に記載された各ステップを実装");
+    expect(result).toContain("自己レビュー");
+    expect(result).toContain("エラーハンドリング");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空の planOutput を処理する", () => {
+    const result = buildDevelopImplPrompt({
+      planOutput: "",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("コードを実装してください");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("計画に記載された各ステップを実装");
+  });
+});

--- a/src/ai/prompts/templates/develop-impl.ts
+++ b/src/ai/prompts/templates/develop-impl.ts
@@ -1,0 +1,29 @@
+export interface DevelopImplContext {
+  planOutput: string;
+  repo: string;
+  branch: string;
+}
+
+export function buildDevelopImplPrompt(context: DevelopImplContext): string {
+  return [
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "以下の実行計画に従って、コードを実装してください。",
+    "",
+    "## リポジトリ情報",
+    `- リポジトリ: ${context.repo}`,
+    `- ブランチ: ${context.branch}`,
+    "",
+    "## 実行計画",
+    context.planOutput,
+    "",
+    "## 指示",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 計画に記載された各ステップを実装してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 実装後、変更内容を確認して自己レビューを行ってください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- エラーハンドリングを適切に行ってください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 既存のテストが通ることを確認してください",
+  ].join("\n");
+}

--- a/src/ai/prompts/templates/develop-plan.test.ts
+++ b/src/ai/prompts/templates/develop-plan.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildDevelopPlanPrompt } from "./develop-plan";
+
+describe("buildDevelopPlanPrompt", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "コンテキスト変数がプロンプトに含まれる", () => {
+    const result = buildDevelopPlanPrompt({
+      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
+      issueBody: "バグを修正する",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("バグを修正する");
+    expect(result).toContain("owner/repo");
+    expect(result).toContain("main");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "期待される指示セクションが生成される", () => {
+    const result = buildDevelopPlanPrompt({
+      issueBody: "test",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("実行計画のみを立案");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("コードは変更せず");
+    expect(result).toContain("マークダウン形式");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空の issueBody を処理する", () => {
+    const result = buildDevelopPlanPrompt({
+      issueBody: "",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("実行計画を作成してください");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("実行計画のみを立案");
+  });
+});

--- a/src/ai/prompts/templates/develop-plan.ts
+++ b/src/ai/prompts/templates/develop-plan.ts
@@ -1,0 +1,31 @@
+export interface DevelopPlanContext {
+  issueBody: string;
+  repo: string;
+  branch: string;
+}
+
+export function buildDevelopPlanPrompt(context: DevelopPlanContext): string {
+  return [
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "以下のIssueに基づいて、実行計画を作成してください。",
+    "",
+    "## リポジトリ情報",
+    `- リポジトリ: ${context.repo}`,
+    `- ブランチ: ${context.branch}`,
+    "",
+    "## Issue内容",
+    context.issueBody,
+    "",
+    "## 指示",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- コードは変更せず、実行計画のみを立案してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- マークダウン形式で出力してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 実装のステップを明確に分けて記載してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 各ステップで変更対象のファイルと変更内容を記載してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 必要に応じて注意点やリスクを含めてください",
+  ].join("\n");
+}

--- a/src/ai/prompts/templates/develop-test.test.ts
+++ b/src/ai/prompts/templates/develop-test.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildDevelopTestPrompt } from "./develop-test";
+
+describe("buildDevelopTestPrompt", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "コンテキスト変数がプロンプトに含まれる", () => {
+    const result = buildDevelopTestPrompt({
+      diff: "+ function add(a, b) { return a + b; }",
+      repo: "owner/repo",
+      branch: "feature/1",
+    });
+    expect(result).toContain("+ function add(a, b) { return a + b; }");
+    expect(result).toContain("owner/repo");
+    expect(result).toContain("feature/1");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "テスト規約が含まれる", () => {
+    const result = buildDevelopTestPrompt({
+      diff: "test diff",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    expect(result).toContain("Vitest");
+    expect(result).toContain("co-locate");
+    expect(result).toContain("*.test.ts");
+    expect(result).toContain("vi.mock()");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空の diff を処理する", () => {
+    const result = buildDevelopTestPrompt({
+      diff: "",
+      repo: "owner/repo",
+      branch: "main",
+    });
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("テストを作成してください");
+    expect(result).toContain("Vitest");
+  });
+});

--- a/src/ai/prompts/templates/develop-test.ts
+++ b/src/ai/prompts/templates/develop-test.ts
@@ -1,0 +1,32 @@
+export interface DevelopTestContext {
+  diff: string;
+  repo: string;
+  branch: string;
+}
+
+export function buildDevelopTestPrompt(context: DevelopTestContext): string {
+  return [
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "以下の実装差分に対するテストを作成してください。",
+    "",
+    "## リポジトリ情報",
+    `- リポジトリ: ${context.repo}`,
+    `- ブランチ: ${context.branch}`,
+    "",
+    "## 実装差分",
+    context.diff,
+    "",
+    "## 指示",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- Vitestを使用してテストを作成してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- テストファイルは対象ファイルと同じディレクトリに配置してください（co-locate）",
+    "- テストファイル名は `*.test.ts` の形式にしてください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- テストケースは日本語のdescribe/itで記述してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 境界値テストとエラーケースを含めてください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- モックが必要な場合は vi.mock() を使用してください",
+  ].join("\n");
+}

--- a/src/shared/utils/format.test.ts
+++ b/src/shared/utils/format.test.ts
@@ -3,39 +3,56 @@ import { DISCORD_MAX_LENGTH } from "@/shared/utils/constants";
 import { formatForDiscord } from "@/shared/utils/format";
 
 describe("formatForDiscord", () => {
-  it("returns empty string as-is", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空文字列はそのまま返る", () => {
     expect(formatForDiscord("")).toBe("");
   });
 
-  it("returns text as-is when within limit", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "制限内のテキストはそのまま返る", () => {
     const text = "short message";
     expect(formatForDiscord(text)).toBe(text);
   });
 
-  it("returns text as-is when exactly at limit", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "ちょうど制限バイトのテキストはそのまま返る", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH);
     expect(formatForDiscord(text)).toBe(text);
   });
+});
 
-  it("truncates and appends omission notice when over limit", () => {
+describe("formatForDiscord: 切り詰め", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "制限超過時は切り詰めて省略通知を付与する", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH + 100);
     const result = formatForDiscord(text);
     // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result).toContain("... (続きは省略されました)");
-    expect(result.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
+      DISCORD_MAX_LENGTH,
+    );
   });
 
-  it("preserves first DISCORD_MAX_LENGTH - 50 characters", () => {
-    const prefix = "b".repeat(DISCORD_MAX_LENGTH - 50);
-    const text = prefix + "x".repeat(100);
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "日本語テキストが制限超過時にバイトベースで切り詰められる", () => {
+    // 日本語1文字 = UTF-8で3バイト
+    // 2000 / 3 ≈ 666文字 + 通知文で制限超過
+    const text = "あ".repeat(700);
     const result = formatForDiscord(text);
-    expect(result.startsWith(prefix)).toBe(true);
+    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
+    expect(result).toContain("... (続きは省略されました)");
+    expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
+      DISCORD_MAX_LENGTH,
+    );
   });
 
-  it("truncates text that is exactly one character over limit", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "1バイトだけ制限を超えるテキストを切り詰める", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH + 1);
     const result = formatForDiscord(text);
-    expect(result.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
+      DISCORD_MAX_LENGTH,
+    );
     // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result).toContain("... (続きは省略されました)");
   });

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -1,9 +1,10 @@
 import { DISCORD_MAX_LENGTH } from "./constants";
+import { truncateToBytes } from "./truncate";
 
 // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
-const OMISSION_NOTICE = "\n\n... (続きは省略されました)";
+const DISCORD_OMISSION_NOTICE = "\n\n... (続きは省略されました)";
 
 export function formatForDiscord(text: string): string {
-  if (text.length <= DISCORD_MAX_LENGTH) return text;
-  return `${text.slice(0, DISCORD_MAX_LENGTH - OMISSION_NOTICE.length)}${OMISSION_NOTICE}`;
+  return truncateToBytes(text, DISCORD_MAX_LENGTH, DISCORD_OMISSION_NOTICE)
+    .text;
 }

--- a/src/shared/utils/truncate.test.ts
+++ b/src/shared/utils/truncate.test.ts
@@ -62,7 +62,6 @@ describe("truncateToBytes: カスタム通知文", () => {
   });
 });
 
-// biome-ignore lint/security/noSecrets: describe block name, not a secret
 describe("truncateToBytes: 境界値", () => {
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
   "1バイトだけ制限を超えるテキストを切り詰める", () => {
@@ -85,12 +84,12 @@ describe("truncateToBytes: 境界値", () => {
   });
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "通知文のバイト長がmaxBytesを超える場合でも切り詰めは実行される", () => {
+  "通知文のバイト長がmaxBytesを超える場合、通知文をmaxBytesに切り詰める", () => {
     const text = "a".repeat(200);
     const longNotice = "X".repeat(200);
     const result = truncateToBytes(text, 100, longNotice);
     expect(result.wasTruncated).toBe(true);
-    expect(result.text).toBe(longNotice);
+    expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
   });
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
@@ -107,10 +106,10 @@ describe("truncateToBytes: 境界値", () => {
   });
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "maxBytesが0の場合、切り詰め結果は通知文のみになる", () => {
+  "maxBytesが0の場合、結果は空文字列になる", () => {
     const text = "hello";
     const result = truncateToBytes(text, 0);
     expect(result.wasTruncated).toBe(true);
-    expect(result.text).toBe("\n\n... (truncated)");
+    expect(result.text).toBe("");
   });
 });

--- a/src/shared/utils/truncate.test.ts
+++ b/src/shared/utils/truncate.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { truncateToBytes } from "./truncate";
+
+describe("truncateToBytes", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "制限内のテキストはそのまま返る", () => {
+    const result = truncateToBytes("hello", 100);
+    expect(result.text).toBe("hello");
+    expect(result.wasTruncated).toBe(false);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "制限超過テキストは切り詰められる", () => {
+    const text = "a".repeat(1000);
+    const result = truncateToBytes(text, 100);
+    expect(result.wasTruncated).toBe(true);
+    expect(result.text).toContain("... (truncated)");
+    expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "境界値: ちょうど制限のテキストは切り詰められない", () => {
+    const text = "あいうえお";
+    const exactBytes = Buffer.byteLength(text, "utf-8");
+    const result = truncateToBytes(text, exactBytes);
+    expect(result.text).toBe(text);
+    expect(result.wasTruncated).toBe(false);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空文字列入力を処理する", () => {
+    const result = truncateToBytes("", 100);
+    expect(result.text).toBe("");
+    expect(result.wasTruncated).toBe(false);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "マルチバイト文字が途中で分割されない", () => {
+    const text = "あいうえおかきくけこ";
+    const result = truncateToBytes(text, 20);
+    expect(result.wasTruncated).toBe(true);
+    const body = result.text.replace("\n\n... (truncated)", "");
+    for (const char of body) {
+      expect("あいうえおかきくけこ".includes(char)).toBe(true);
+    }
+  });
+});
+
+// biome-ignore lint/security/noSecrets: describe block name, not a secret
+describe("truncateToBytes: カスタム通知文", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "カスタム通知文を使用できる", () => {
+    const text = "a".repeat(1000);
+    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
+    const notice = "\n\n... (続きは省略されました)";
+    const result = truncateToBytes(text, 100, notice);
+    expect(result.wasTruncated).toBe(true);
+    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
+    expect(result.text).toContain("続きは省略されました)");
+    expect(result.text).not.toContain("... (truncated)");
+    expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
+  });
+});
+
+// biome-ignore lint/security/noSecrets: describe block name, not a secret
+describe("truncateToBytes: 境界値", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "1バイトだけ制限を超えるテキストを切り詰める", () => {
+    const text = "a".repeat(101);
+    const result = truncateToBytes(text, 100);
+    expect(result.wasTruncated).toBe(true);
+    expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
+    expect(result.text).toContain("... (truncated)");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "maxBytesが通知文のバイト長と等しい場合、本文は空になる", () => {
+    const notice = "\n\n... (truncated)";
+    const noticeBytes = Buffer.byteLength(notice, "utf-8");
+    const text = "a".repeat(noticeBytes + 10);
+    const result = truncateToBytes(text, noticeBytes);
+    expect(result.wasTruncated).toBe(true);
+    expect(result.text).toBe(notice);
+    expect(Buffer.byteLength(result.text, "utf-8")).toBe(noticeBytes);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "通知文のバイト長がmaxBytesを超える場合でも切り詰めは実行される", () => {
+    const text = "a".repeat(200);
+    const longNotice = "X".repeat(200);
+    const result = truncateToBytes(text, 100, longNotice);
+    expect(result.wasTruncated).toBe(true);
+    expect(result.text).toBe(longNotice);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "ASCIIとマルチバイト混在テキストの切り詰め境界で文字が分割されない", () => {
+    const text = "aあaあaあaあaあ";
+    const shortNotice = "…";
+    const result = truncateToBytes(text, 10, shortNotice);
+    expect(result.wasTruncated).toBe(true);
+    expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(10);
+    const body = result.text.slice(0, -shortNotice.length);
+    for (const char of body) {
+      expect("aあ").toContain(char);
+    }
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "maxBytesが0の場合、切り詰め結果は通知文のみになる", () => {
+    const text = "hello";
+    const result = truncateToBytes(text, 0);
+    expect(result.wasTruncated).toBe(true);
+    expect(result.text).toBe("\n\n... (truncated)");
+  });
+});

--- a/src/shared/utils/truncate.ts
+++ b/src/shared/utils/truncate.ts
@@ -18,6 +18,20 @@ export function truncateToBytes(
   const noticeBytes = Buffer.byteLength(notice, "utf-8");
   const safeLimit = maxBytes - noticeBytes;
 
+  if (safeLimit < 0) {
+    let lo = 0;
+    let hi = notice.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (Buffer.byteLength(notice.slice(0, mid), "utf-8") <= maxBytes) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return { text: notice.slice(0, lo), wasTruncated: true };
+  }
+
   let low = 0;
   let high = text.length;
   while (low < high) {

--- a/src/shared/utils/truncate.ts
+++ b/src/shared/utils/truncate.ts
@@ -1,0 +1,33 @@
+const DEFAULT_TRUNCATION_NOTICE = "\n\n... (truncated)";
+
+export interface TruncateResult {
+  text: string;
+  wasTruncated: boolean;
+}
+
+export function truncateToBytes(
+  text: string,
+  maxBytes: number,
+  notice: string = DEFAULT_TRUNCATION_NOTICE,
+): TruncateResult {
+  const byteLength = Buffer.byteLength(text, "utf-8");
+  if (byteLength <= maxBytes) {
+    return { text, wasTruncated: false };
+  }
+
+  const noticeBytes = Buffer.byteLength(notice, "utf-8");
+  const safeLimit = maxBytes - noticeBytes;
+
+  let low = 0;
+  let high = text.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, mid), "utf-8") <= safeLimit) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return { text: text.slice(0, low) + notice, wasTruncated: true };
+}


### PR DESCRIPTION
# チケット

close #13

# 概要

Issue #13 に対応し、developワークフローで使用する4つのプロンプトテンプレート（plan / impl / test / commit）と、バイトベースのテキスト切り詰めユーティリティを追加しました。

### 追加したプロンプトテンプレート

- **develop-plan**: Issue本文から実装計画を生成するプロンプト
- **develop-impl**: 計画に基づいてコード実装を行うプロンプト
- **develop-test**: 差分からテストコードを生成するプロンプト
- **develop-commit**: 差分からコミットメッセージを生成するプロンプト

### ユーティリティ改善

- **truncateToBytes**: 二分探索によるバイトベースのテキスト切り詰めユーティリティを新規追加。マルチバイト文字の分割を防ぎます。
- **formatForDiscord**: 上記`truncateToBytes`を利用するようリファクタリングし、日本語等のマルチバイト文字列でも正しくDiscordのメッセージ長制限内に収まるよう改善しました。

# その他

resolves #13