### PR TITLE
✨ メッセージ送信・スレッド管理・フォーマット機能を追加

### DIFF
--- a/src/bot/utils/message-formatter.test.ts
+++ b/src/bot/utils/message-formatter.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "vitest";
+import type { IssueInfo } from "@/infrastructure/github/github.client";
+import type { Phase } from "@/infrastructure/redis/thread-state.types";
+import { DISCORD_MAX_LENGTH } from "@/shared/utils/constants";
+import { MessageFormatter } from "./message-formatter";
+
+function createIssueInfo(overrides: Partial<IssueInfo> = {}): IssueInfo {
+  return {
+    number: 42,
+    title: "Test Issue",
+    body: "This is a test issue body",
+    owner: "test-owner",
+    repo: "test-repo",
+    state: "open",
+    labels: [],
+    assignees: [],
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("MessageFormatter.splitMessage basic", () => {
+  it("returns single-element array for text under limit", () => {
+    const text = "Hello, world!";
+    const result = MessageFormatter.splitMessage(text);
+    expect(result).toEqual(["Hello, world!"]);
+  });
+
+  it("returns single-element array for text at exactly maxLength", () => {
+    const text = "a".repeat(DISCORD_MAX_LENGTH);
+    const result = MessageFormatter.splitMessage(text);
+    expect(result).toEqual([text]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns array with empty string for empty input", () => {
+    const result = MessageFormatter.splitMessage("");
+    expect(result).toEqual([""]);
+  });
+});
+
+describe("MessageFormatter.splitMessage splitting", () => {
+  it("splits text over maxLength into multiple chunks", () => {
+    const line = "a".repeat(1000);
+    const text = `${line}\n${line}\n${line}`;
+    const result = MessageFormatter.splitMessage(text);
+    expect(result.length).toBeGreaterThan(1);
+    for (const chunk of result) {
+      expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    }
+  });
+
+  it("splits at newline boundaries", () => {
+    const line = "a".repeat(1500);
+    const text = `${line}\n${line}`;
+    const result = MessageFormatter.splitMessage(text);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe(line);
+    expect(result[1]).toBe(line);
+  });
+
+  it("handles text with no newlines by hard splitting", () => {
+    const text = "a".repeat(DISCORD_MAX_LENGTH + 100);
+    const result = MessageFormatter.splitMessage(text);
+    expect(result.length).toBe(2);
+    expect(result[0].length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+  });
+
+  it("splits text of maxLength + 1 into exactly two chunks", () => {
+    const text = "a".repeat(DISCORD_MAX_LENGTH + 1);
+    const result = MessageFormatter.splitMessage(text);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe("a".repeat(DISCORD_MAX_LENGTH));
+    expect(result[1]).toBe("a");
+  });
+
+  it("hard splits when only newline is at position 0", () => {
+    const text = `\n${"a".repeat(DISCORD_MAX_LENGTH)}`;
+    const result = MessageFormatter.splitMessage(text);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(`\n${"a".repeat(DISCORD_MAX_LENGTH - 1)}`);
+    expect(result[1]).toBe("a");
+  });
+});
+
+describe("MessageFormatter.splitMessage code blocks", () => {
+  it("closes and reopens code blocks at split boundaries", () => {
+    const code = "a".repeat(1990);
+    const text = `\`\`\`\n${code}\nmore content`;
+    const result = MessageFormatter.splitMessage(text);
+    expect(result.length).toBeGreaterThan(1);
+    expect(result[0].endsWith("```")).toBe(true);
+    expect(result[1].startsWith("```")).toBe(true);
+  });
+
+  it("does not confuse inline code with code fences", () => {
+    const text = `some \`inline code\` here\n${"b".repeat(2000)}`;
+    const result = MessageFormatter.splitMessage(text);
+    expect(result.length).toBe(2);
+    expect(result[0]).toBe("some `inline code` here");
+  });
+
+  it("handles multiple code blocks correctly", () => {
+    const block1 = "x".repeat(800);
+    const block2 = "y".repeat(800);
+    const text = `\`\`\`\n${block1}\n\`\`\`\nmiddle\n\`\`\`\n${block2}\n\`\`\``;
+    const result = MessageFormatter.splitMessage(text);
+    for (const chunk of result) {
+      const fences = chunk.match(/(?<!`)```(?!`)/g);
+      if (fences) {
+        expect(fences.length % 2).toBe(0);
+      }
+    }
+  });
+});
+
+describe("MessageFormatter.formatDiff", () => {
+  it("wraps short diff in diff code block", () => {
+    const diff = "+ added line\n- removed line";
+    const result = MessageFormatter.formatDiff(diff);
+    expect(result).toEqual(["```diff\n+ added line\n- removed line\n```"]);
+  });
+
+  it("truncates long diff with notice", () => {
+    const diff = "+ ".repeat(5000);
+    const result = MessageFormatter.formatDiff(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0].startsWith("```diff\n")).toBe(true);
+    expect(result[0].endsWith("\n```")).toBe(true);
+    expect(result[0]).toContain("... (truncated)");
+    expect(result[0].length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+  });
+
+  it("returns code block for empty diff", () => {
+    const result = MessageFormatter.formatDiff("");
+    expect(result).toEqual(["```diff\n\n```"]);
+  });
+
+  it("does not truncate when diff byte length exactly equals available space", () => {
+    const codeBlockOverhead = "\n```".length + "```diff\n".length;
+    const available = DISCORD_MAX_LENGTH - codeBlockOverhead;
+    const diff = "+".repeat(available);
+
+    const result = MessageFormatter.formatDiff(diff);
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toContain("... (truncated)");
+  });
+});
+
+describe("MessageFormatter.formatPhaseStatus", () => {
+  const phases: Phase[] = [
+    "init",
+    "planned",
+    "developed",
+    "tested",
+    "committed",
+    "completed",
+  ];
+
+  it.each(phases)("generates correct message for phase %s", (phase) => {
+    const issueInfo = createIssueInfo({ number: 42, title: "Fix bug" });
+    const result = MessageFormatter.formatPhaseStatus(phase, issueInfo);
+    expect(result).toContain("Issue #42");
+    expect(result).toContain("Fix bug");
+  });
+
+  it("includes issue number and title", () => {
+    const issueInfo = createIssueInfo({ number: 99, title: "New Feature" });
+    const result = MessageFormatter.formatPhaseStatus("init", issueInfo);
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    expect(result).toBe("Issue #99: New Feature の開発を開始します");
+  });
+});
+
+describe("MessageFormatter.formatError", () => {
+  it("includes error text", () => {
+    const result = MessageFormatter.formatError("Something went wrong", "init");
+    expect(result).toContain("Something went wrong");
+  });
+
+  it("includes reset guidance", () => {
+    const result = MessageFormatter.formatError("Error", "planned");
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    expect(result).toContain("/resetでやり直せます");
+  });
+
+  it("includes phase name", () => {
+    const result = MessageFormatter.formatError("Error", "tested");
+    expect(result).toContain("testedフェーズ");
+  });
+});
+
+describe("MessageFormatter.formatInitMessage", () => {
+  it("includes issue number and title", () => {
+    const issueInfo = createIssueInfo({ number: 7, title: "Add feature" });
+    const result = MessageFormatter.formatInitMessage(issueInfo);
+    expect(result).toContain("Issue #7");
+    expect(result).toContain("Add feature");
+  });
+
+  it("includes body when present", () => {
+    const issueInfo = createIssueInfo({ body: "Detailed description" });
+    const result = MessageFormatter.formatInitMessage(issueInfo);
+    expect(result).toContain("説明: Detailed description");
+  });
+
+  it("omits body line when body is null", () => {
+    const issueInfo = createIssueInfo({ body: null });
+    const result = MessageFormatter.formatInitMessage(issueInfo);
+    expect(result).not.toContain("説明:");
+  });
+
+  it("truncates long body to 500 characters", () => {
+    const issueInfo = createIssueInfo({ body: "x".repeat(1000) });
+    const result = MessageFormatter.formatInitMessage(issueInfo);
+    const bodyLine = result.split("\n").find((l) => l.startsWith("説明:"));
+    expect(bodyLine).toBeDefined();
+    expect(bodyLine?.length).toBeLessThanOrEqual("説明: ".length + 500);
+  });
+
+  it("does not truncate body when exactly 500 characters", () => {
+    const issueInfo = createIssueInfo({ body: "x".repeat(500) });
+    const result = MessageFormatter.formatInitMessage(issueInfo);
+    const bodyLine = result.split("\n").find((l) => l.startsWith("説明:"));
+    expect(bodyLine).toBe(`説明: ${"x".repeat(500)}`);
+  });
+});
+
+describe("MessageFormatter.formatPhaseResult", () => {
+  it("includes result text", () => {
+    const result = MessageFormatter.formatPhaseResult("init", "Plan created");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.some((r) => r.includes("Plan created"))).toBe(true);
+  });
+
+  it("includes next step for non-completed phases", () => {
+    const result = MessageFormatter.formatPhaseResult("init", "done");
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    expect(result.some((r) => r.includes("計画を作成します..."))).toBe(true);
+  });
+
+  it("does not include next step for completed phase", () => {
+    const result = MessageFormatter.formatPhaseResult("completed", "All done");
+    expect(result.every((r) => !r.includes("..."))).toBe(true);
+  });
+
+  it("splits long results into multiple messages", () => {
+    const longResult = "x".repeat(DISCORD_MAX_LENGTH + 1000);
+    const result = MessageFormatter.formatPhaseResult("init", longResult);
+    expect(result.length).toBeGreaterThan(1);
+    for (const chunk of result) {
+      expect(chunk.length).toBeLessThanOrEqual(DISCORD_MAX_LENGTH);
+    }
+  });
+
+  it.each([
+    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
+    ["planned", "開発を開始します..."],
+    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
+    ["developed", "テストを実行します..."],
+    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
+    ["tested", "コミットを作成します..."],
+  ] as [
+    Phase,
+    string,
+  ][])("includes correct next step for %s phase", (phase, nextStep) => {
+    const result = MessageFormatter.formatPhaseResult(phase, "done");
+    expect(result.some((r) => r.includes(nextStep))).toBe(true);
+  });
+
+  it("includes completion message for committed phase", () => {
+    const result = MessageFormatter.formatPhaseResult("committed", "done");
+    expect(result.some((r) => r.includes("完了しました"))).toBe(true);
+  });
+});

--- a/src/bot/utils/message-formatter.ts
+++ b/src/bot/utils/message-formatter.ts
@@ -1,0 +1,124 @@
+import type { IssueInfo } from "@/infrastructure/github/github.client";
+import type { Phase } from "@/infrastructure/redis/thread-state.types";
+import { DISCORD_MAX_LENGTH } from "@/shared/utils/constants";
+import { truncateToBytes } from "@/shared/utils/truncate";
+
+const CODE_BLOCK_OVERHEAD = "\n```".length + "```diff\n".length;
+const BODY_MAX_LENGTH = 500;
+const DIFF_TRUNCATION_NOTICE = "\n... (truncated)";
+
+const PHASE_STATUS_MESSAGES: Record<Phase, string> = {
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  init: "開発を開始します",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  planned: "計画が完了しました",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  developed: "実装が完了しました",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  tested: "テストが完了しました",
+  committed: "コミットが完了しました",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  completed: "開発が完了しました",
+};
+
+const NEXT_STEP_MESSAGES: Record<Phase, string | null> = {
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  init: "計画を作成します...",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  planned: "開発を開始します...",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  developed: "テストを実行します...",
+  // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+  tested: "コミットを作成します...",
+  committed: "完了しました",
+  completed: null,
+};
+
+// biome-ignore lint/complexity/noStaticOnlyClass: Issue spec requires static utility class
+export class MessageFormatter {
+  static splitMessage(
+    text: string,
+    maxLength: number = DISCORD_MAX_LENGTH,
+  ): string[] {
+    if (text.length <= maxLength) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > maxLength) {
+      let splitAt = remaining.lastIndexOf("\n", maxLength);
+
+      if (splitAt <= 0) splitAt = maxLength;
+
+      let chunk = remaining.slice(0, splitAt);
+      remaining = remaining.slice(splitAt);
+
+      if (remaining.startsWith("\n")) remaining = remaining.slice(1);
+
+      const fenceCount = countCodeFences(chunk);
+      if (fenceCount % 2 !== 0) {
+        chunk = `${chunk}\n\`\`\``;
+        remaining = `\`\`\`\n${remaining}`;
+      }
+
+      chunks.push(chunk);
+    }
+
+    if (remaining.length > 0) chunks.push(remaining);
+
+    return chunks;
+  }
+
+  static formatDiff(diff: string): string[] {
+    const available = DISCORD_MAX_LENGTH - CODE_BLOCK_OVERHEAD;
+
+    if (Buffer.byteLength(diff, "utf-8") <= available) {
+      return [`\`\`\`diff\n${diff}\n\`\`\``];
+    }
+
+    const truncated = truncateToBytes(diff, available, DIFF_TRUNCATION_NOTICE);
+    return [`\`\`\`diff\n${truncated.text}\n\`\`\``];
+  }
+
+  static formatPhaseStatus(phase: Phase, issueInfo: IssueInfo): string {
+    const status = PHASE_STATUS_MESSAGES[phase];
+    return `Issue #${issueInfo.number}: ${issueInfo.title} の${status}`;
+  }
+
+  static formatError(error: string, phase: Phase): string {
+    return `エラーが発生しました (${phase}フェーズ)\n${error}\n\n/resetでやり直せます`;
+  }
+
+  static formatInitMessage(issueInfo: IssueInfo): string {
+    const bodyLine = issueInfo.body
+      ? `\n説明: ${issueInfo.body.slice(0, BODY_MAX_LENGTH)}`
+      : "";
+
+    return [
+      `Issue #${issueInfo.number} の開発を開始します`,
+      "",
+      `タイトル: ${issueInfo.title}${bodyLine}`,
+      "",
+      // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+      "自動で 計画→開発→テスト→コミット の流れで進めます。",
+    ].join("\n");
+  }
+
+  static formatPhaseResult(phase: Phase, result: string): string[] {
+    const status = PHASE_STATUS_MESSAGES[phase];
+    const header = `${status}\n\n`;
+    const nextStep = NEXT_STEP_MESSAGES[phase];
+
+    let message = `${header}${result}`;
+    if (nextStep) message = `${message}\n\n${nextStep}`;
+
+    return MessageFormatter.splitMessage(message);
+  }
+}
+
+function countCodeFences(text: string): number {
+  let count = 0;
+  const pattern = /(?<!`)```(?!`)/g;
+  while (pattern.exec(text) !== null) count++;
+  return count;
+}

--- a/src/bot/utils/thread-manager.test.ts
+++ b/src/bot/utils/thread-manager.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: mockLogInfo,
+    error: mockLogError,
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const mockSendChannelMessage = vi.fn();
+const mockCreateThreadFromMessage = vi.fn();
+const mockArchiveThread = vi.fn();
+
+const mockDiscordClient = {
+  sendChannelMessage: mockSendChannelMessage,
+  createThreadFromMessage: mockCreateThreadFromMessage,
+  archiveThread: mockArchiveThread,
+} as never;
+
+const { ThreadManager } = await import("./thread-manager");
+
+function createManager() {
+  return new ThreadManager(mockDiscordClient);
+}
+
+describe("ThreadManager.createDevThread returns thread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns threadId on success", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue("thread-456");
+    const manager = createManager();
+
+    const result = await manager.createDevThread("ch-1", 42, "Fix bug");
+
+    expect(result).toBe("thread-456");
+  });
+
+  it("sends correct message content with issue number", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue("thread-456");
+    const manager = createManager();
+
+    await manager.createDevThread("ch-1", 42, "Fix bug");
+
+    expect(mockSendChannelMessage).toHaveBeenCalledWith(
+      "ch-1",
+      "Issue #42 開発スレッド",
+    );
+  });
+});
+
+describe("ThreadManager.createDevThread thread name", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("formats thread name as #number title", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue("thread-456");
+    const manager = createManager();
+
+    await manager.createDevThread("ch-1", 42, "Fix bug");
+
+    expect(mockCreateThreadFromMessage).toHaveBeenCalledWith(
+      "ch-1",
+      "msg-123",
+      "#42 Fix bug",
+    );
+  });
+
+  it("truncates long thread name to 100 characters", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue("thread-456");
+    const manager = createManager();
+
+    const longTitle = "a".repeat(150);
+    await manager.createDevThread("ch-1", 42, longTitle);
+
+    const threadName = mockCreateThreadFromMessage.mock.calls[0][2] as string;
+    expect(threadName.length).toBeLessThanOrEqual(100);
+    expect(threadName).toBe(`#42 ${longTitle}`.slice(0, 100));
+  });
+
+  it("does not truncate thread name when exactly 100 characters", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue("thread-456");
+    const manager = createManager();
+
+    const title = "a".repeat(96);
+    await manager.createDevThread("ch-1", 42, title);
+
+    const threadName = mockCreateThreadFromMessage.mock.calls[0][2] as string;
+    expect(threadName).toBe(`#42 ${title}`);
+    expect(threadName).toHaveLength(100);
+  });
+});
+
+describe("ThreadManager.createDevThread failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when message send fails", async () => {
+    mockSendChannelMessage.mockResolvedValue(null);
+    const manager = createManager();
+
+    const result = await manager.createDevThread("ch-1", 42, "Fix bug");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { channelId: "ch-1", issueNumber: 42 },
+      "Failed to send initial message for dev thread",
+    );
+  });
+
+  it("returns null when thread creation fails", async () => {
+    mockSendChannelMessage.mockResolvedValue("msg-123");
+    mockCreateThreadFromMessage.mockResolvedValue(null);
+    const manager = createManager();
+
+    const result = await manager.createDevThread("ch-1", 42, "Fix bug");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { channelId: "ch-1", issueNumber: 42, messageId: "msg-123" },
+      "Failed to create dev thread",
+    );
+  });
+});
+
+describe("ThreadManager.archiveThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("completes without error on success", async () => {
+    mockArchiveThread.mockResolvedValue(true);
+    const manager = createManager();
+
+    await expect(manager.archiveThread("thread-456")).resolves.toBeUndefined();
+  });
+
+  it("logs error on failure", async () => {
+    mockArchiveThread.mockResolvedValue(false);
+    const manager = createManager();
+
+    await manager.archiveThread("thread-456");
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      { threadId: "thread-456" },
+      "Failed to archive thread",
+    );
+  });
+});

--- a/src/bot/utils/thread-manager.ts
+++ b/src/bot/utils/thread-manager.ts
@@ -1,0 +1,54 @@
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import { getLogger } from "@/shared/utils/logger";
+
+const THREAD_NAME_MAX_LENGTH = 100;
+
+export class ThreadManager {
+  constructor(private readonly discordClient: DiscordClient) {}
+
+  async createDevThread(
+    channelId: string,
+    issueNumber: number,
+    issueTitle: string,
+  ): Promise<string | null> {
+    const log = getLogger();
+    const rawName = `#${issueNumber} ${issueTitle}`;
+    const threadName = rawName.slice(0, THREAD_NAME_MAX_LENGTH);
+
+    const messageId = await this.discordClient.sendChannelMessage(
+      channelId,
+      `Issue #${issueNumber} 開発スレッド`,
+    );
+    if (!messageId) {
+      log.error(
+        { channelId, issueNumber },
+        "Failed to send initial message for dev thread",
+      );
+      return null;
+    }
+
+    const threadId = await this.discordClient.createThreadFromMessage(
+      channelId,
+      messageId,
+      threadName,
+    );
+    if (!threadId) {
+      log.error(
+        { channelId, issueNumber, messageId },
+        "Failed to create dev thread",
+      );
+      return null;
+    }
+
+    log.info({ threadId, issueNumber, threadName }, "Dev thread created");
+    return threadId;
+  }
+
+  async archiveThread(threadId: string): Promise<void> {
+    const log = getLogger();
+    const success = await this.discordClient.archiveThread(threadId);
+    if (!success) {
+      log.error({ threadId }, "Failed to archive thread");
+    }
+  }
+}

--- a/src/sdk/discord/discord.client.test.ts
+++ b/src/sdk/discord/discord.client.test.ts
@@ -252,6 +252,145 @@ describe("DiscordClient createThreadFromMessage error", () => {
   });
 });
 
+describe("DiscordClient sendChannelMessage success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns message ID on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "msg-new" }),
+    });
+    const client = createClient();
+
+    const result = await client.sendChannelMessage("ch-123", "Hello!");
+
+    expect(result).toBe("msg-new");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/ch-123/messages",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bot test-token",
+        },
+        body: JSON.stringify({ content: "Hello!" }),
+      },
+    );
+  });
+
+  it("returns null when response has no id", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const client = createClient();
+
+    const result = await client.sendChannelMessage("ch-123", "Hello!");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("DiscordClient sendChannelMessage error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null on API error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    });
+    const client = createClient();
+
+    const result = await client.sendChannelMessage("ch-123", "Hello!");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 403, body: "Forbidden", channelId: "ch-123" },
+      "Failed to send channel message",
+    );
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = createClient();
+
+    const result = await client.sendChannelMessage("ch-123", "Hello!");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", channelId: "ch-123" },
+      "Channel message request failed",
+    );
+  });
+});
+
+describe("DiscordClient archiveThread success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = createClient();
+
+    const result = await client.archiveThread("thread-123");
+
+    expect(result).toBe(true);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/thread-123",
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bot test-token",
+        },
+        body: JSON.stringify({ archived: true }),
+      },
+    );
+  });
+});
+
+describe("DiscordClient archiveThread error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false on API error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    });
+    const client = createClient();
+
+    const result = await client.archiveThread("thread-123");
+
+    expect(result).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 403, body: "Forbidden", threadId: "thread-123" },
+      "Failed to archive thread",
+    );
+  });
+
+  it("returns false on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = createClient();
+
+    const result = await client.archiveThread("thread-123");
+
+    expect(result).toBe(false);
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", threadId: "thread-123" },
+      "Thread archive request failed",
+    );
+  });
+});
+
 const testCommands = [
   {
     name: "ping",

--- a/src/sdk/discord/discord.client.ts
+++ b/src/sdk/discord/discord.client.ts
@@ -165,6 +165,66 @@ export class DiscordClient {
     }
   }
 
+  async sendChannelMessage(
+    channelId: string,
+    content: string,
+  ): Promise<string | null> {
+    const log = getLogger();
+    try {
+      const response = await this.discordApiFetch(
+        `/channels/${channelId}/messages`,
+        "POST",
+        { content },
+      );
+
+      if (!response.ok) {
+        const body = await response.text();
+        log.error(
+          { status: response.status, body, channelId },
+          "Failed to send channel message",
+        );
+        return null;
+      }
+
+      const data = (await response.json()) as { id?: string };
+      return data.id ?? null;
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e), channelId },
+        "Channel message request failed",
+      );
+      return null;
+    }
+  }
+
+  async archiveThread(threadId: string): Promise<boolean> {
+    const log = getLogger();
+    try {
+      const response = await this.discordApiFetch(
+        `/channels/${threadId}`,
+        "PATCH",
+        { archived: true },
+      );
+
+      if (!response.ok) {
+        const body = await response.text();
+        log.error(
+          { status: response.status, body, threadId },
+          "Failed to archive thread",
+        );
+        return false;
+      }
+
+      return true;
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e), threadId },
+        "Thread archive request failed",
+      );
+      return false;
+    }
+  }
+
   async registerGuildCommands(
     guildId: string,
     commands: Command[],


### PR DESCRIPTION
# チケット

close #14

# 概要

Discordボットのメッセージ送信・スレッド管理・フォーマット機能を追加しました。

### 変更内容

- **DiscordClient**: `sendChannelMessage`（チャンネルへのメッセージ送信）と `archiveThread`（スレッドのアーカイブ）メソッドを追加
- **ThreadManager**: スレッドの作成・メッセージ送信・アーカイブを統合的に管理するユーティリティを追加
- **MessageFormatter**: Discord向けのメッセージフォーマット（コードブロック引用や通知文の切り詰め等）を提供するユーティリティを追加

# その他

resolves #14