### PR TITLE
✨ developコマンド（init/plan/develop/test/commit/pr/reset）を追加

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,21 @@
 			"semicolons": "always"
 		}
 	},
+	"overrides": [
+		{
+			"includes": ["**/*.test.ts"],
+			"linter": {
+				"rules": {
+					"security": {
+						"noSecrets": "off"
+					},
+					"complexity": {
+						"noExcessiveLinesPerFunction": "off"
+					}
+				}
+			}
+		}
+	],
 	"assist": {
 		"enabled": true,
 		"actions": {

--- a/src/ai/prompts/templates/develop-commit.test.ts
+++ b/src/ai/prompts/templates/develop-commit.test.ts
@@ -2,22 +2,18 @@ import { describe, expect, it } from "vitest";
 import { buildDevelopCommitPrompt } from "./develop-commit";
 
 describe("buildDevelopCommitPrompt", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "コンテキスト変数がプロンプトに含まれる", () => {
+  it("コンテキスト変数がプロンプトに含まれる", () => {
     const result = buildDevelopCommitPrompt({
       diff: "+ function hello() { return 'hi'; }",
       issueNumber: 42,
-      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
       issueTitle: "新機能を追加",
     });
     expect(result).toContain("+ function hello() { return 'hi'; }");
     expect(result).toContain("#42");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("新機能を追加");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "期待される指示が生成される", () => {
+  it("期待される指示が生成される", () => {
     const result = buildDevelopCommitPrompt({
       diff: "test diff",
       issueNumber: 1,
@@ -27,8 +23,7 @@ describe("buildDevelopCommitPrompt", () => {
     expect(result).toContain("git commit -m");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空の diff を処理する", () => {
+  it("空の diff を処理する", () => {
     const result = buildDevelopCommitPrompt({
       diff: "",
       issueNumber: 1,

--- a/src/ai/prompts/templates/develop-impl.test.ts
+++ b/src/ai/prompts/templates/develop-impl.test.ts
@@ -2,43 +2,35 @@ import { describe, expect, it } from "vitest";
 import { buildDevelopImplPrompt } from "./develop-impl";
 
 describe("buildDevelopImplPrompt", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "コンテキスト変数がプロンプトに含まれる", () => {
+  it("コンテキスト変数がプロンプトに含まれる", () => {
     const result = buildDevelopImplPrompt({
-      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
       planOutput: "ステップ1: ファイルを作成する",
       repo: "owner/repo",
       branch: "feature/1",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("ステップ1: ファイルを作成する");
     expect(result).toContain("owner/repo");
     expect(result).toContain("feature/1");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "期待される指示が生成される", () => {
+  it("期待される指示が生成される", () => {
     const result = buildDevelopImplPrompt({
       planOutput: "test",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("計画に記載された各ステップを実装");
     expect(result).toContain("自己レビュー");
     expect(result).toContain("エラーハンドリング");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空の planOutput を処理する", () => {
+  it("空の planOutput を処理する", () => {
     const result = buildDevelopImplPrompt({
       planOutput: "",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("コードを実装してください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("計画に記載された各ステップを実装");
   });
 });

--- a/src/ai/prompts/templates/develop-plan.test.ts
+++ b/src/ai/prompts/templates/develop-plan.test.ts
@@ -2,44 +2,35 @@ import { describe, expect, it } from "vitest";
 import { buildDevelopPlanPrompt } from "./develop-plan";
 
 describe("buildDevelopPlanPrompt", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "コンテキスト変数がプロンプトに含まれる", () => {
+  it("コンテキスト変数がプロンプトに含まれる", () => {
     const result = buildDevelopPlanPrompt({
-      // biome-ignore lint/security/noSecrets: Japanese test data, not a secret
       issueBody: "バグを修正する",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("バグを修正する");
     expect(result).toContain("owner/repo");
     expect(result).toContain("main");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "期待される指示セクションが生成される", () => {
+  it("期待される指示セクションが生成される", () => {
     const result = buildDevelopPlanPrompt({
       issueBody: "test",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("実行計画のみを立案");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("コードは変更せず");
     expect(result).toContain("マークダウン形式");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空の issueBody を処理する", () => {
+  it("空の issueBody を処理する", () => {
     const result = buildDevelopPlanPrompt({
       issueBody: "",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("実行計画を作成してください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("実行計画のみを立案");
   });
 });

--- a/src/ai/prompts/templates/develop-test.test.ts
+++ b/src/ai/prompts/templates/develop-test.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildDevelopTestPrompt } from "./develop-test";
 
 describe("buildDevelopTestPrompt", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "コンテキスト変数がプロンプトに含まれる", () => {
+  it("コンテキスト変数がプロンプトに含まれる", () => {
     const result = buildDevelopTestPrompt({
       diff: "+ function add(a, b) { return a + b; }",
       repo: "owner/repo",
@@ -14,8 +13,7 @@ describe("buildDevelopTestPrompt", () => {
     expect(result).toContain("feature/1");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "テスト規約が含まれる", () => {
+  it("テスト規約が含まれる", () => {
     const result = buildDevelopTestPrompt({
       diff: "test diff",
       repo: "owner/repo",
@@ -27,14 +25,12 @@ describe("buildDevelopTestPrompt", () => {
     expect(result).toContain("vi.mock()");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空の diff を処理する", () => {
+  it("空の diff を処理する", () => {
     const result = buildDevelopTestPrompt({
       diff: "",
       repo: "owner/repo",
       branch: "main",
     });
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("テストを作成してください");
     expect(result).toContain("Vitest");
   });

--- a/src/ai/prompts/templates/general-chat.test.ts
+++ b/src/ai/prompts/templates/general-chat.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { buildGeneralChatPrompt } from "./general-chat";
 
-// biome-ignore lint/security/noSecrets: test description, not a secret
 describe("buildGeneralChatPrompt", () => {
   it("returns message as-is", () => {
     const result = buildGeneralChatPrompt("こんにちは");

--- a/src/ai/prompts/templates/summary.test.ts
+++ b/src/ai/prompts/templates/summary.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildSummaryPrompt } from "./summary";
 
 describe("buildSummaryPrompt", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "単一コンテンツのプロンプトを生成する", () => {
+  it("単一コンテンツのプロンプトを生成する", () => {
     const result = buildSummaryPrompt([
       { url: "https://example.com", text: "Hello world" },
     ]);
@@ -12,8 +11,7 @@ describe("buildSummaryPrompt", () => {
     expect(result).toContain("要約してください");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "複数コンテンツのプロンプトを生成する", () => {
+  it("複数コンテンツのプロンプトを生成する", () => {
     const contents = [
       { url: "https://example.com", text: "Content A" },
       { url: "https://example.org", text: "Content B" },
@@ -25,15 +23,11 @@ describe("buildSummaryPrompt", () => {
     expect(result).toContain("Content B");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空配列を渡した場合でもヘッダーと要件は含まれる", () => {
+  it("空配列を渡した場合でもヘッダーと要件は含まれる", () => {
     const result = buildSummaryPrompt([]);
     expect(result).toContain("要約してください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("日本語で要約してください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("箇条書きで含めてください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("各URLごとに要約を分けて記載してください");
   });
 });

--- a/src/ai/prompts/templates/url-review.test.ts
+++ b/src/ai/prompts/templates/url-review.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { buildUrlReviewPrompt } from "./url-review";
 
-// biome-ignore lint/security/noSecrets: test description, not a secret
 describe("buildUrlReviewPrompt", () => {
   it("builds base prompt with URL only", () => {
     const result = buildUrlReviewPrompt("https://example.com");
     expect(result).toContain("https://example.com");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("以下のURLの内容を読み取り、解説してください");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).not.toContain("特に以下の点について");
   });
 
@@ -17,13 +14,11 @@ describe("buildUrlReviewPrompt", () => {
       "https://example.com",
       "セキュリティについて",
     );
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).toContain("特に以下の点について：セキュリティについて");
   });
 
   it("omits question section when question is empty string", () => {
     const result = buildUrlReviewPrompt("https://example.com", "");
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(result).not.toContain("特に以下の点について");
   });
 

--- a/src/ai/services/summary.service.test.ts
+++ b/src/ai/services/summary.service.test.ts
@@ -42,8 +42,7 @@ describe("SummaryService", () => {
     vi.restoreAllMocks();
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "URL一覧を渡して要約結果を返す", async () => {
+  it("URL一覧を渡して要約結果を返す", async () => {
     const client = createMockOpenAIClient("AI summary");
     const fetcher = createMockWebFetcher(
       new Map([["https://example.com", "page content"]]),
@@ -71,8 +70,7 @@ describe("SummaryService", () => {
     ]);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "全URL取得失敗時はerrを返す", async () => {
+  it("全URL取得失敗時はerrを返す", async () => {
     const client = createMockOpenAIClient("response");
     const fetcher = createMockWebFetcher(new Map());
     const service = new SummaryService(client, fetcher);
@@ -81,8 +79,7 @@ describe("SummaryService", () => {
     expect(result.ok).toBe(false);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "OpenAIエラー時はerrを返す", async () => {
+  it("OpenAIエラー時はerrを返す", async () => {
     const client = {
       chat: vi.fn().mockRejectedValue(new Error("API error")),
     } as unknown as OpenAIClient;

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -21,6 +21,14 @@ const mockRedisDisconnect = vi.fn().mockResolvedValue(undefined);
 const mockRedisConnect = vi.fn().mockResolvedValue(undefined);
 const mockRegisterGuildCommands = vi.fn().mockResolvedValue(undefined);
 
+const defaultConfig = {
+  bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+  server: { port: 3000 },
+  logging: { level: "info" },
+  github: { owner: "test-owner", repo: "test-repo" },
+  workspace: { root: "/tmp/workspace" },
+};
+
 function setupMocks(
   config: Record<string, unknown>,
   envOverrides?: Record<string, unknown>,
@@ -100,6 +108,94 @@ function setupMocks(
       return {};
     }),
   }));
+  vi.doMock("@/infrastructure/github/github.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    GitHubClient: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  }));
+  vi.doMock("@/infrastructure/workspace/workspace.manager", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    WorkspaceManager: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  }));
+  vi.doMock("@/ai/client/codex-exec.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    CodexExecClient: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/init.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    InitCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "init",
+        definition: { description: "Init" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/plan.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    PlanCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "plan",
+        definition: { description: "Plan" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/develop.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    DevelopCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "develop",
+        definition: { description: "Develop" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/test.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    TestCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "test",
+        definition: { description: "Test" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/commit.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    CommitCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "commit",
+        definition: { description: "Commit" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/pr.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    PrCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "pr",
+        definition: { description: "PR" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/bot/commands/develop/reset.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    ResetCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "reset",
+        definition: { description: "Reset" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
 }
 
 describe("bootstrap result", () => {
@@ -111,11 +207,7 @@ describe("bootstrap result", () => {
   });
 
   it("returns app with fetch method and port from config", async () => {
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: { level: "info" },
-    });
+    setupMocks(defaultConfig);
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -126,11 +218,7 @@ describe("bootstrap result", () => {
   });
 
   it("passes interactionHandler to createApp", async () => {
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: { level: "info" },
-    });
+    setupMocks(defaultConfig);
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -153,11 +241,7 @@ describe("bootstrap shutdown", () => {
   });
 
   it("returns shutdown function", async () => {
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: { level: "info" },
-    });
+    setupMocks(defaultConfig);
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -167,11 +251,7 @@ describe("bootstrap shutdown", () => {
   });
 
   it("shutdown disconnects Redis and stops Gateway", async () => {
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: { level: "info" },
-    });
+    setupMocks(defaultConfig);
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -183,11 +263,7 @@ describe("bootstrap shutdown", () => {
   });
 
   it("shutdown always stops Gateway", async () => {
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: { level: "info" },
-    });
+    setupMocks(defaultConfig);
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -210,11 +286,7 @@ describe("bootstrap logging", () => {
 
   it("calls createLogger with logging config", async () => {
     const loggingConfig = { level: "debug" };
-    setupMocks({
-      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-      server: { port: 3000 },
-      logging: loggingConfig,
-    });
+    setupMocks({ ...defaultConfig, logging: loggingConfig });
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -228,6 +300,8 @@ describe("bootstrap logging", () => {
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
       logging: { level: "info" },
+      github: { owner: "test-owner", repo: "test-repo" },
+      workspace: { root: "/tmp/workspace" },
     };
     setupMocks(config);
 
@@ -262,14 +336,10 @@ describe("bootstrap error", () => {
   });
 
   it("throws when OPENAI_API_KEY and CODEX_API_KEY are not set", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { OPENAI_API_KEY: undefined, CODEX_API_KEY: undefined },
-    );
+    setupMocks(defaultConfig, {
+      OPENAI_API_KEY: undefined,
+      CODEX_API_KEY: undefined,
+    });
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -288,14 +358,10 @@ describe("bootstrap API key selection", () => {
   });
 
   it("prefers CODEX_API_KEY over OPENAI_API_KEY", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { CODEX_API_KEY: "codex-key", OPENAI_API_KEY: "openai-key" },
-    );
+    setupMocks(defaultConfig, {
+      CODEX_API_KEY: "codex-key",
+      OPENAI_API_KEY: "openai-key",
+    });
 
     const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
@@ -309,14 +375,10 @@ describe("bootstrap API key selection", () => {
   });
 
   it("falls back to OPENAI_API_KEY when CODEX_API_KEY is not set", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { CODEX_API_KEY: undefined, OPENAI_API_KEY: "openai-key" },
-    );
+    setupMocks(defaultConfig, {
+      CODEX_API_KEY: undefined,
+      OPENAI_API_KEY: "openai-key",
+    });
 
     const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
@@ -339,17 +401,10 @@ describe("bootstrap OpenAIClient options", () => {
   });
 
   it("passes CODEX_BASE_URL and CODEX_MODEL to OpenAIClient", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      {
-        CODEX_BASE_URL: "https://custom.api",
-        CODEX_MODEL: "custom-model",
-      },
-    );
+    setupMocks(defaultConfig, {
+      CODEX_BASE_URL: "https://custom.api",
+      CODEX_MODEL: "custom-model",
+    });
 
     const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
@@ -376,14 +431,7 @@ describe("bootstrap guild command registration", () => {
   });
 
   it("calls registerGuildCommands when DISCORD_GUILD_ID is set", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { DISCORD_GUILD_ID: "guild-123" },
-    );
+    setupMocks(defaultConfig, { DISCORD_GUILD_ID: "guild-123" });
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -400,14 +448,7 @@ describe("bootstrap guild command registration", () => {
   });
 
   it("does not call registerGuildCommands when DISCORD_GUILD_ID is not set", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { DISCORD_GUILD_ID: undefined },
-    );
+    setupMocks(defaultConfig, { DISCORD_GUILD_ID: undefined });
 
     const { bootstrap } = await import("@/app/bootstrap");
 

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -21,7 +21,6 @@ const mockRedisDisconnect = vi.fn().mockResolvedValue(undefined);
 const mockRedisConnect = vi.fn().mockResolvedValue(undefined);
 const mockRegisterGuildCommands = vi.fn().mockResolvedValue(undefined);
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: mock setup with many vi.doMock calls
 function setupMocks(
   config: Record<string, unknown>,
   envOverrides?: Record<string, unknown>,

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,31 +1,45 @@
 import { createDiscordAdapter } from "@chat-adapter/discord";
+import { CodexExecClient } from "@/ai/client/codex-exec.client";
 import { OpenAIClient } from "@/ai/client/openai.client";
 import { AIService } from "@/ai/services/ai.service";
 import { SummaryService } from "@/ai/services/summary.service";
-import { loadConfig } from "@/app/config/bot.config";
+import { type BotConfig, loadConfig } from "@/app/config/bot.config";
 import { env } from "@/app/config/env";
 import { ChatCommand } from "@/bot/commands/ai/chat.command";
 import { SummaryCommand } from "@/bot/commands/ai/summary.command";
+import type { Command } from "@/bot/commands/command.interface";
+import { CommitCommand } from "@/bot/commands/develop/commit.command";
+import { DevelopCommand } from "@/bot/commands/develop/develop.command";
+import { InitCommand } from "@/bot/commands/develop/init.command";
+import { PlanCommand } from "@/bot/commands/develop/plan.command";
+import { PrCommand } from "@/bot/commands/develop/pr.command";
+import { ResetCommand } from "@/bot/commands/develop/reset.command";
+import { TestCommand } from "@/bot/commands/develop/test.command";
 import { PingCommand } from "@/bot/commands/utility/ping.command";
 import { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import { MessageHandler } from "@/bot/handlers/message.handler";
 import { Router } from "@/bot/router";
+import { GitHubClient } from "@/infrastructure/github/github.client";
 import { RedisClient } from "@/infrastructure/redis/redis.client";
 import { WebFetcherClient } from "@/infrastructure/web/web-fetcher.client";
+import { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
 import { DiscordClient } from "@/sdk/discord/discord.client";
 import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
 import { createLogger, getLogger } from "@/shared/utils/logger";
+
+function getCodexApiKey(): string {
+  const key = env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
+  if (!key) throw new Error("CODEX_API_KEY or OPENAI_API_KEY is required");
+  return key;
+}
 
 function createAIService(): {
   aiService: AIService;
   redis: RedisClient;
   openai: OpenAIClient;
 } {
-  const codexApiKey = env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
-  if (!codexApiKey) {
-    throw new Error("CODEX_API_KEY or OPENAI_API_KEY is required");
-  }
+  const codexApiKey = getCodexApiKey();
   const openai = new OpenAIClient(codexApiKey, {
     baseUrl: env.CODEX_BASE_URL,
     model: env.CODEX_MODEL,
@@ -38,21 +52,88 @@ function createAIService(): {
   return { aiService: new AIService(openai, redis), redis, openai };
 }
 
-function createDiscordDeps(aiService: AIService, openai: OpenAIClient) {
+function createDevelopCommands(
+  redis: RedisClient,
+  config: BotConfig,
+  discordClient: DiscordClient,
+): Command[] {
+  const codexApiKey = getCodexApiKey();
+  const githubOwner = config.github.owner;
+  const githubRepo = config.github.repo;
+  const github = new GitHubClient();
+  const workspace = new WorkspaceManager(config.workspace.root);
+  const codexExec = new CodexExecClient(codexApiKey, {
+    baseUrl: env.CODEX_BASE_URL,
+    model: env.CODEX_MODEL,
+  });
+
+  return [
+    new InitCommand({
+      redis,
+      github,
+      workspace,
+      discordClient,
+      githubOwner,
+      githubRepo,
+    }),
+    new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner,
+      githubRepo,
+    }),
+    new DevelopCommand({ redis, codexExec, workspace, discordClient }),
+    new TestCommand({ redis, codexExec, workspace, discordClient }),
+    new CommitCommand({
+      redis,
+      codexExec,
+      workspace,
+      github,
+      discordClient,
+      githubOwner,
+      githubRepo,
+    }),
+    new PrCommand({
+      redis,
+      codexExec,
+      github,
+      workspace,
+      discordClient,
+      githubOwner,
+      githubRepo,
+    }),
+    new ResetCommand({ redis, workspace, discordClient }),
+  ];
+}
+
+function createDiscordDeps(
+  aiService: AIService,
+  openai: OpenAIClient,
+  redis: RedisClient,
+  config: BotConfig,
+) {
   const botToken = env.DISCORD_BOT_TOKEN;
   const applicationId = env.DISCORD_APPLICATION_ID;
   if (!botToken) throw new Error("DISCORD_BOT_TOKEN is required");
   if (!applicationId) throw new Error("DISCORD_APPLICATION_ID is required");
 
-  const adapter = createDiscordAdapter({
-    botToken,
-    applicationId,
-  });
+  const adapter = createDiscordAdapter({ botToken, applicationId });
   const discordClient = new DiscordClient(adapter, botToken, applicationId);
+
   const chatCommand = new ChatCommand(aiService, discordClient);
   const summaryService = new SummaryService(openai, new WebFetcherClient());
   const summaryCommand = new SummaryCommand(summaryService, discordClient);
-  const commands = [new PingCommand(), chatCommand, summaryCommand];
+  const developCommands = createDevelopCommands(redis, config, discordClient);
+
+  const commands: Command[] = [
+    new PingCommand(),
+    chatCommand,
+    summaryCommand,
+    ...developCommands,
+  ];
+
   const messageHandler = new MessageHandler(
     aiService,
     discordClient,
@@ -95,7 +176,7 @@ export function bootstrap() {
     interactionHandler,
     messageHandler,
     discordClient,
-  } = createDiscordDeps(aiService, openai);
+  } = createDiscordDeps(aiService, openai, redis, config);
 
   const app = createApp({
     interactionHandler,

--- a/src/app/config/bot.config.test.ts
+++ b/src/app/config/bot.config.test.ts
@@ -5,6 +5,9 @@ vi.mock("node:fs", () => ({
   readFileSync: vi.fn(),
 }));
 
+const github = { owner: "test-owner", repo: "test-repo" };
+const workspace = { root: "/tmp/workspace" };
+
 const validYaml = `
 bot:
   defaultModel: "codex-mini"
@@ -12,6 +15,11 @@ bot:
   timeoutMs: 30000
 server:
   port: 3000
+github:
+  owner: "test-owner"
+  repo: "test-repo"
+workspace:
+  root: "/tmp/workspace"
 redis:
   url: "redis://localhost:6379"
 `;
@@ -25,6 +33,8 @@ describe("botConfigSchema valid", () => {
         timeoutMs: 30000,
       },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result).toEqual({
@@ -34,6 +44,8 @@ describe("botConfigSchema valid", () => {
         timeoutMs: 30000,
       },
       server: { port: 3000 },
+      github,
+      workspace,
     });
   });
 
@@ -41,6 +53,8 @@ describe("botConfigSchema valid", () => {
     const result = botConfigSchema.parse({
       bot: { defaultModel: "model", maxTokens: 0, timeoutMs: 30000 },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result.bot.maxTokens).toBe(0);
@@ -50,6 +64,8 @@ describe("botConfigSchema valid", () => {
     const result = botConfigSchema.parse({
       bot: { defaultModel: "model", maxTokens: 4096, timeoutMs: 0 },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result.bot.timeoutMs).toBe(0);
@@ -66,6 +82,8 @@ describe("botConfigSchema allowedUsers", () => {
         allowedUsers: ["user-1", "user-2"],
       },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result.bot.allowedUsers).toEqual(["user-1", "user-2"]);
@@ -75,6 +93,8 @@ describe("botConfigSchema allowedUsers", () => {
     const result = botConfigSchema.parse({
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result.bot.allowedUsers).toBeUndefined();
@@ -89,6 +109,8 @@ describe("botConfigSchema allowedUsers", () => {
         allowedUsers: [],
       },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result.bot.allowedUsers).toEqual([]);
@@ -104,6 +126,8 @@ describe("botConfigSchema allowedUsers", () => {
           allowedUsers: "not-an-array",
         },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -118,6 +142,8 @@ describe("botConfigSchema allowedUsers", () => {
           allowedUsers: [123],
         },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -129,6 +155,8 @@ describe("botConfigSchema invalid bot fields", () => {
       botConfigSchema.parse({
         bot: { maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -138,6 +166,8 @@ describe("botConfigSchema invalid bot fields", () => {
       botConfigSchema.parse({
         bot: { defaultModel: "", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -151,6 +181,8 @@ describe("botConfigSchema invalid bot fields", () => {
           timeoutMs: 30000,
         },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -160,6 +192,8 @@ describe("botConfigSchema invalid bot fields", () => {
       botConfigSchema.parse({
         bot: { defaultModel: "codex-mini", maxTokens: -1, timeoutMs: 30000 },
         server: { port: 3000 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -175,6 +209,8 @@ describe("botConfigSchema invalid server fields", () => {
           timeoutMs: 30000,
         },
         server: {},
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -184,6 +220,8 @@ describe("botConfigSchema invalid server fields", () => {
       botConfigSchema.parse({
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 0 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -193,6 +231,8 @@ describe("botConfigSchema invalid server fields", () => {
       botConfigSchema.parse({
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: -1 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -203,6 +243,8 @@ describe("botConfigSchema logging valid", () => {
     const result = botConfigSchema.parse({
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result).not.toHaveProperty("logging");
@@ -225,6 +267,8 @@ describe("botConfigSchema logging valid", () => {
       },
       server: { port: 3000 },
       logging: { level },
+      github,
+      workspace,
     });
 
     expect(result.logging?.level).toBe(level);
@@ -235,6 +279,8 @@ describe("botConfigSchema logging valid", () => {
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
       logging: {},
+      github,
+      workspace,
     });
 
     expect(result.logging).toEqual({});
@@ -252,6 +298,8 @@ describe("botConfigSchema logging invalid", () => {
         },
         server: { port: 3000 },
         logging: { level: "verbose" },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -266,6 +314,8 @@ describe("botConfigSchema logging invalid", () => {
         },
         server: { port: 3000 },
         logging: { level: 123 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -276,6 +326,8 @@ describe("botConfigSchema redis valid", () => {
     const result = botConfigSchema.parse({
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
+      github,
+      workspace,
     });
 
     expect(result).not.toHaveProperty("redis");
@@ -286,6 +338,8 @@ describe("botConfigSchema redis valid", () => {
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
       redis: { url: "redis://localhost:6379" },
+      github,
+      workspace,
     });
 
     expect(result.redis?.url).toBe("redis://localhost:6379");
@@ -299,6 +353,8 @@ describe("botConfigSchema redis invalid", () => {
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 3000 },
         redis: { url: "" },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -309,6 +365,8 @@ describe("botConfigSchema redis invalid", () => {
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 3000 },
         redis: { url: 123 },
+        github,
+        workspace,
       }),
     ).toThrow();
   });
@@ -338,6 +396,8 @@ describe("loadConfig", () => {
         timeoutMs: 30000,
       },
       server: { port: 3000 },
+      github,
+      workspace,
       redis: { url: "redis://localhost:6379" },
     });
   });

--- a/src/app/config/bot.config.ts
+++ b/src/app/config/bot.config.ts
@@ -32,6 +32,13 @@ export const botConfigSchema = z.object({
       url: z.string().min(1),
     })
     .optional(),
+  github: z.object({
+    owner: z.string().min(1),
+    repo: z.string().min(1),
+  }),
+  workspace: z.object({
+    root: z.string().min(1),
+  }),
 });
 
 export type BotConfig = z.infer<typeof botConfigSchema>;

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -13,3 +13,10 @@ logging:
 
 redis:
   url: "redis://localhost:6379"
+
+github:
+  owner: "yukihito-jokyu"
+  repo: "discord-codex-develop"
+
+workspace:
+  root: "/tmp/codex-workspace"

--- a/src/bot/commands/ai/chat.command.test.ts
+++ b/src/bot/commands/ai/chat.command.test.ts
@@ -71,7 +71,6 @@ describe("ChatCommand properties", () => {
       options: [
         {
           name: "message",
-          // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
           description: "AIに送信するメッセージ",
           type: 3,
           required: true,
@@ -229,7 +228,6 @@ describe("ChatCommand error in thread", () => {
 
     expect(discordClient.sendMessage).toHaveBeenCalledWith(
       "thread-999",
-      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       "エラーが発生しました。しばらくしてからお試しください。",
     );
   });

--- a/src/bot/commands/ai/summary.command.test.ts
+++ b/src/bot/commands/ai/summary.command.test.ts
@@ -59,7 +59,6 @@ describe("SummaryCommand properties", () => {
       createMockDiscordClient(),
     );
     expect(command.definition).toEqual({
-      // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
       description: "フォーラム投稿のリンクを要約",
     });
   });
@@ -92,7 +91,6 @@ describe("SummaryCommand no message", () => {
 
     expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
       "token-1",
-      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       expect.stringContaining("メッセージの取得に失敗"),
     );
   });
@@ -161,7 +159,6 @@ describe("SummaryCommand service error", () => {
 
     expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
       "token-1",
-      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       expect.stringContaining("要約の生成に失敗"),
     );
   });

--- a/src/bot/commands/develop/commit.command.test.ts
+++ b/src/bot/commands/develop/commit.command.test.ts
@@ -1,0 +1,312 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { CommitCommand } from "./commit.command";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("@/ai/prompts/templates/develop-commit", () => ({
+  buildDevelopCommitPrompt: vi.fn().mockReturnValue("built-commit-prompt"),
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "thread-1",
+    userId: "user-1",
+    commandName: "commit",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 15,
+    repo: "test-repo",
+    branch: "feature/15",
+    workspacePath: "/workspace/test-repo",
+    currentPhase: "tested",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function createMockRedisClient(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExecClient(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "commit response",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "commit response",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+function createMockGitHubClient(): GitHubClient {
+  return {
+    getIssue: vi.fn().mockResolvedValue(
+      ok({
+        number: 15,
+        title: "Test",
+        body: "body",
+        owner: "o",
+        repo: "r",
+        state: "open",
+        labels: [],
+        assignees: [],
+        createdAt: "",
+        updatedAt: "",
+      }),
+    ),
+    createPullRequest: vi
+      .fn()
+      .mockResolvedValue(
+        ok({ url: "https://github.com/o/r/pull/1", number: 1 }),
+      ),
+  } as unknown as GitHubClient;
+}
+
+function createMockWorkspaceManager(): WorkspaceManager {
+  return {
+    getDiff: vi.fn().mockResolvedValue(ok("diff content")),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+function createCommandDeps() {
+  return {
+    redis: createMockRedisClient(),
+    codexExec: createMockCodexExecClient(),
+    workspace: createMockWorkspaceManager(),
+    github: createMockGitHubClient(),
+    discordClient: createMockDiscordClient(),
+    githubOwner: "o",
+    githubRepo: "r",
+  };
+}
+
+describe("CommitCommand properties", () => {
+  it("has name 'commit'", () => {
+    const command = new CommitCommand(createCommandDeps());
+    expect(command.name).toBe("commit");
+  });
+});
+
+describe("CommitCommand deferred response", () => {
+  let command: CommitCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new CommitCommand(deps);
+  });
+
+  it("returns deferred response immediately", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("CommitCommand validates thread", () => {
+  let command: CommitCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new CommitCommand(deps);
+  });
+
+  it("requires phase 'tested'", async () => {
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.workspace.getDiff).toHaveBeenCalled();
+  });
+
+  it("rejects when phase is wrong", async () => {
+    deps.redis.getThreadState = vi
+      .fn()
+      .mockResolvedValue(createMockThreadState({ currentPhase: "developed" }));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "現在のフェーズが不正です (現在: developed, 期待: tested)",
+    );
+    expect(deps.workspace.getDiff).not.toHaveBeenCalled();
+  });
+});
+
+describe("CommitCommand success flow", () => {
+  let command: CommitCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new CommitCommand(deps);
+  });
+
+  it("gets diff, fetches issue for title, builds commit prompt, executes codex, updates phase to committed", async () => {
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    // Gets diff from workspace
+    expect(deps.workspace.getDiff).toHaveBeenCalledWith("/workspace/test-repo");
+
+    // Fetches issue for title
+    expect(deps.github.getIssue).toHaveBeenCalledWith("o", "r", 15);
+
+    // Builds commit prompt (mocked, but we verify codexExec was called)
+    expect(deps.codexExec.startThread).toHaveBeenCalledWith(
+      "built-commit-prompt",
+      expect.objectContaining({
+        cwd: "/workspace/test-repo",
+        sandboxMode: "write",
+      }),
+    );
+
+    // Updates phase to committed
+    expect(deps.redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "thread-1",
+      "tested",
+      "committed",
+    );
+
+    // Saves thread state
+    expect(deps.redis.saveThreadState).toHaveBeenCalled();
+
+    // Responds with formatted output
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      expect.any(String),
+    );
+  });
+});
+
+describe("CommitCommand diff fetch failure", () => {
+  let command: CommitCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new CommitCommand(deps);
+  });
+
+  it("returns error when workspace.getDiff returns err", async () => {
+    deps.workspace.getDiff = vi
+      .fn()
+      .mockResolvedValue(err(new AppError("diff failed", "DIFF_ERROR")));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "diffの取得に失敗しました: diff failed",
+    );
+
+    // Should not proceed to codex execution
+    expect(deps.codexExec.startThread).not.toHaveBeenCalled();
+
+    // subStage should be reset to idle
+    expect(deps.redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({ subStage: "idle" }),
+    );
+  });
+});
+
+describe("CommitCommand codex failure", () => {
+  let command: CommitCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new CommitCommand(deps);
+  });
+
+  it("handles error when codex throws", async () => {
+    deps.codexExec.startThread = vi
+      .fn()
+      .mockRejectedValue(new Error("codex crashed"));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "コミット中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+
+    expect(deps.redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "codex crashed",
+      }),
+    );
+  });
+});

--- a/src/bot/commands/develop/commit.command.ts
+++ b/src/bot/commands/develop/commit.command.ts
@@ -1,0 +1,171 @@
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import { buildDevelopCommitPrompt } from "@/ai/prompts/templates/develop-commit";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+interface CommitCommandDeps {
+  redis: RedisClient;
+  codexExec: CodexExecClient;
+  workspace: WorkspaceManager;
+  github: GitHubClient;
+  discordClient: DiscordClient;
+  githubOwner: string;
+  githubRepo: string;
+}
+
+export class CommitCommand implements Command {
+  readonly name = "commit";
+  readonly definition = {
+    description: "変更をコミット",
+  };
+
+  constructor(private readonly deps: CommitCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "CommitCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async buildCommitPrompt(
+    state: import("@/infrastructure/redis/thread-state.types").ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<string | null> {
+    const { workspace, github, discordClient, githubOwner, githubRepo } =
+      this.deps;
+
+    const diffResult = await workspace.getDiff(state.workspacePath);
+    if (!diffResult.ok) {
+      const { redis } = this.deps;
+      state.subStage = "idle";
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `diffの取得に失敗しました: ${diffResult.error.message}`,
+      );
+      return null;
+    }
+
+    const issueResult = await github.getIssue(
+      githubOwner,
+      githubRepo,
+      state.issueNumber,
+    );
+    const issueTitle = issueResult.ok
+      ? issueResult.value.title
+      : `Issue #${state.issueNumber}`;
+
+    return buildDevelopCommitPrompt({
+      diff: diffResult.value,
+      issueNumber: state.issueNumber,
+      issueTitle,
+    });
+  }
+
+  private async executeCommit(
+    state: import("@/infrastructure/redis/thread-state.types").ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, codexExec, discordClient } = this.deps;
+
+    const prompt = await this.buildCommitPrompt(
+      state,
+      channelId,
+      interactionToken,
+    );
+    if (!prompt) return;
+
+    const codexResult = await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId,
+      phase: "commit",
+      prompt,
+      cwd: state.workspacePath,
+      sandboxMode: "write",
+    });
+
+    state.subStage = "idle";
+    const casSuccess = await redis.compareAndSwapPhase(
+      channelId,
+      "tested",
+      "committed",
+    );
+    if (!casSuccess) state.currentPhase = "committed";
+    await redis.saveThreadState(channelId, state);
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      formatForDiscord(codexResult.response),
+    );
+    log.info(
+      { channelId, issueNumber: state.issueNumber },
+      "CommitCommand completed",
+    );
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const vr = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ["tested"],
+      interactionToken,
+    });
+    if (!vr) return;
+
+    const state = vr.state;
+    state.subStage = "running";
+    await redis.saveThreadState(channelId, state);
+
+    try {
+      await this.executeCommit(state, channelId, interactionToken);
+    } catch (err) {
+      const log = getLogger();
+      log.error({ err: String(err) }, "CommitCommand error");
+      state.subStage = "idle";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "コミット中にエラーが発生しました。しばらくしてから再試行してください。",
+      );
+    }
+  }
+}

--- a/src/bot/commands/develop/develop.command.test.ts
+++ b/src/bot/commands/develop/develop.command.test.ts
@@ -1,0 +1,400 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { ok } from "@/shared/types/result";
+import { DevelopCommand } from "./develop.command";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("@/ai/prompts/templates/develop-impl", () => ({
+  buildDevelopImplPrompt: vi.fn().mockReturnValue("built-develop-prompt"),
+}));
+
+vi.mock("./validate", () => ({
+  validateThreadCommand: vi.fn(),
+  executeCodexOrResume: vi.fn(),
+}));
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "thread-1",
+    userId: "user-1",
+    commandName: "develop",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 42,
+    repo: "owner/repo",
+    branch: "feature/42",
+    workspacePath: "/workspace/issue-42",
+    currentPhase: "planned",
+    subStage: "idle",
+    lastError: null,
+    planOutput: "plan text",
+    ...overrides,
+  };
+}
+
+function createMockRedis(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExec(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "response text",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "response text",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+function createMockWorkspace(): WorkspaceManager {
+  return {
+    getDiff: vi.fn().mockResolvedValue(ok("diff content")),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+    sendMessage: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("DevelopCommand properties", () => {
+  it("has name 'develop'", () => {
+    const command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.name).toBe("develop");
+  });
+
+  it("has definition with description", () => {
+    const command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.definition).toEqual({
+      description: "計画に基づいてコードを実装",
+    });
+  });
+});
+
+describe("DevelopCommand deferred response", () => {
+  let command: DevelopCommand;
+
+  beforeEach(() => {
+    command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("returns deferred response immediately", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("DevelopCommand thread validation", () => {
+  let command: DevelopCommand;
+
+  beforeEach(() => {
+    command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("validates thread with expected phase 'planned'", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(validateThreadCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedPhases: ["planned"],
+      }),
+    );
+  });
+
+  it("does nothing when validateThreadCommand returns null (wrong phase)", async () => {
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockClear();
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(executeCodexOrResume).not.toHaveBeenCalled();
+  });
+});
+
+describe("DevelopCommand success flow - full execution", () => {
+  let command: DevelopCommand;
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    redis = createMockRedis();
+    codexExec = createMockCodexExec();
+    workspace = createMockWorkspace();
+    discordClient = createMockDiscordClient();
+    command = new DevelopCommand({
+      redis,
+      codexExec,
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("builds prompt, executes codex, gets diff, updates phase to 'developed'", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex response text",
+      usage: null,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(executeCodexOrResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "develop",
+        prompt: "built-develop-prompt",
+        cwd: "/workspace/issue-42",
+        sandboxMode: "write",
+      }),
+    );
+
+    expect(workspace.getDiff).toHaveBeenCalledWith("/workspace/issue-42");
+    expect(redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "thread-1",
+      "planned",
+      "developed",
+    );
+    expect(redis.saveThreadState).toHaveBeenCalledWith("thread-1", state);
+  });
+});
+
+describe("DevelopCommand success flow - response content", () => {
+  let command: DevelopCommand;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    workspace = createMockWorkspace();
+    discordClient = createMockDiscordClient();
+    command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("sends diff when diff is available", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex response text",
+      usage: null,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "**実装完了**\n\n```diff\ndiff content\n```",
+    );
+  });
+
+  it("uses codex response text when diff is empty", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex response text",
+      usage: null,
+    });
+    (workspace.getDiff as ReturnType<typeof vi.fn>).mockResolvedValue(ok(""));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "codex response text",
+    );
+  });
+});
+
+describe("DevelopCommand error handling", () => {
+  let command: DevelopCommand;
+  let redis: RedisClient;
+
+  beforeEach(() => {
+    redis = createMockRedis();
+    command = new DevelopCommand({
+      redis,
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("handles codex execution failure", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AppError("codex failed", "CODEX_ERROR"),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "codex failed",
+      }),
+    );
+  });
+
+  it("handles non-Error thrown value in codex execution", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      "string error",
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        lastError: "string error",
+      }),
+    );
+  });
+});
+
+describe("DevelopCommand error handling - discord response", () => {
+  let command: DevelopCommand;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    discordClient = createMockDiscordClient();
+    command = new DevelopCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("sends error message to discord on codex failure", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AppError("codex failed", "CODEX_ERROR"),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "実装中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+  });
+});

--- a/src/bot/commands/develop/develop.command.ts
+++ b/src/bot/commands/develop/develop.command.ts
@@ -1,0 +1,133 @@
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import { buildDevelopImplPrompt } from "@/ai/prompts/templates/develop-impl";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+interface DevelopCommandDeps {
+  redis: RedisClient;
+  codexExec: CodexExecClient;
+  workspace: WorkspaceManager;
+  discordClient: DiscordClient;
+}
+
+export class DevelopCommand implements Command {
+  readonly name = "develop";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "計画に基づいてコードを実装",
+  };
+
+  constructor(private readonly deps: DevelopCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "DevelopCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async executeDevelop(
+    state: import("@/infrastructure/redis/thread-state.types").ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, codexExec, workspace, discordClient } = this.deps;
+
+    const prompt = buildDevelopImplPrompt({
+      planOutput: state.planOutput ?? "",
+      repo: state.repo,
+      branch: state.branch,
+    });
+    const codexResult = await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId,
+      phase: "develop",
+      prompt,
+      cwd: state.workspacePath,
+      sandboxMode: "write",
+    });
+    const diffResult = await workspace.getDiff(state.workspacePath);
+    const diffText = diffResult.ok ? diffResult.value : "";
+
+    state.subStage = "idle";
+    const casSuccess = await redis.compareAndSwapPhase(
+      channelId,
+      "planned",
+      "developed",
+    );
+    if (!casSuccess) state.currentPhase = "developed";
+    await redis.saveThreadState(channelId, state);
+
+    const responseText = diffText
+      ? `**実装完了**\n\n\`\`\`diff\n${formatForDiscord(diffText)}\n\`\`\``
+      : formatForDiscord(codexResult.response);
+    await discordClient.editInteractionResponse(interactionToken, responseText);
+    log.info(
+      { channelId, issueNumber: state.issueNumber },
+      "DevelopCommand completed",
+    );
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const vr = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ["planned"],
+      interactionToken,
+    });
+    if (!vr) return;
+
+    const state = vr.state;
+    state.subStage = "running";
+    await redis.saveThreadState(channelId, state);
+
+    try {
+      await this.executeDevelop(state, channelId, interactionToken);
+    } catch (err) {
+      const log = getLogger();
+      log.error({ err: String(err) }, "DevelopCommand error");
+      state.subStage = "idle";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "実装中にエラーが発生しました。しばらくしてから再試行してください。",
+      );
+    }
+  }
+}

--- a/src/bot/commands/develop/init.command.test.ts
+++ b/src/bot/commands/develop/init.command.test.ts
@@ -1,0 +1,365 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { InitCommand } from "./init.command";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "channel-1",
+    userId: "user-1",
+    commandName: "init",
+    options: { "issue-number": 15 },
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockRedisClient(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(null),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockGitHubClient(): GitHubClient {
+  return {
+    getIssue: vi.fn().mockResolvedValue(
+      ok({
+        number: 15,
+        title: "Test Issue",
+        body: "body",
+        owner: "owner",
+        repo: "repo",
+        state: "open" as const,
+        labels: [],
+        assignees: [],
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      }),
+    ),
+  } as unknown as GitHubClient;
+}
+
+function createMockWorkspaceManager(): WorkspaceManager {
+  return {
+    ensureClone: vi.fn().mockResolvedValue(ok(undefined)),
+    syncMain: vi.fn().mockResolvedValue(ok(undefined)),
+    createBranch: vi.fn().mockResolvedValue(ok(undefined)),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    isThreadChannel: vi.fn().mockResolvedValue(false),
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-id"),
+    createThreadFromMessage: vi.fn().mockResolvedValue("thread-id"),
+  } as unknown as DiscordClient;
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createCommand(overrides: Record<string, unknown> = {}) {
+  const redis = createMockRedisClient();
+  const github = createMockGitHubClient();
+  const workspace = createMockWorkspaceManager();
+  const discordClient = createMockDiscordClient();
+  const command = new InitCommand({
+    redis,
+    github,
+    workspace,
+    discordClient,
+    githubOwner: "test-owner",
+    githubRepo: "test-repo",
+    ...overrides,
+  });
+  return { command, redis, github, workspace, discordClient };
+}
+
+describe("InitCommand properties", () => {
+  it('has name "init"', () => {
+    const { command } = createCommand();
+    expect(command.name).toBe("init");
+  });
+
+  it("has definition with correct description and options", () => {
+    const { command } = createCommand();
+    expect(command.definition).toEqual({
+      description: "Issueから開発ワークフローを初期化",
+      options: [
+        {
+          name: "issue-number",
+          description: "Issue番号",
+          type: 4,
+          required: true,
+        },
+      ],
+    });
+  });
+});
+
+describe("InitCommand execute", () => {
+  let command: InitCommand;
+
+  beforeEach(() => {
+    ({ command } = createCommand());
+    vi.restoreAllMocks();
+  });
+
+  it("returns deferred response on valid token", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error when no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("InitCommand validation", () => {
+  let redis: RedisClient;
+  let discordClient: DiscordClient;
+  let command: InitCommand;
+
+  beforeEach(() => {
+    ({ command, redis, discordClient } = createCommand());
+    vi.restoreAllMocks();
+  });
+
+  it("rejects non-positive issue number", async () => {
+    await command.execute(
+      createInteraction({ options: { "issue-number": -1 } }),
+    );
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "Issue番号は正の整数で指定してください。",
+    );
+  });
+
+  it("rejects zero issue number", async () => {
+    await command.execute(
+      createInteraction({ options: { "issue-number": 0 } }),
+    );
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "Issue番号は正の整数で指定してください。",
+    );
+  });
+
+  it("rejects non-integer issue number", async () => {
+    await command.execute(
+      createInteraction({ options: { "issue-number": 3.5 } }),
+    );
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "Issue番号は正の整数で指定してください。",
+    );
+  });
+
+  it("rejects when called inside a thread", async () => {
+    (
+      discordClient.isThreadChannel as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(true);
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "このコマンドはスレッド外のチャンネルで実行してください。",
+    );
+  });
+
+  it("rejects when existing workflow is running (subStage === 'running')", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue({
+      initiatedBy: "user-1",
+      issueNumber: 10,
+      subStage: "running",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "現在別の処理が実行中です。完了してから再試行してください。",
+    );
+  });
+
+  it("rejects when different user tries to re-init", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue({
+      initiatedBy: "other-user",
+      issueNumber: 10,
+      subStage: "idle",
+    });
+
+    await command.execute(createInteraction({ userId: "user-1" }));
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "このワークフローは別のユーザーが初期化しました。",
+    );
+  });
+});
+
+describe("InitCommand error handling", () => {
+  let github: GitHubClient;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+  let command: InitCommand;
+
+  beforeEach(() => {
+    const vars = createCommand();
+    github = vars.github;
+    workspace = vars.workspace;
+    discordClient = vars.discordClient;
+    command = vars.command;
+    vi.restoreAllMocks();
+  });
+
+  it("handles github.getIssue failure", async () => {
+    (github.getIssue as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("not found", "NOT_FOUND")),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "Issue #15 の取得に失敗しました: not found",
+    );
+  });
+
+  it("handles workspace.ensureClone failure", async () => {
+    (workspace.ensureClone as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("clone failed", "EXTERNAL_SERVICE_ERROR")),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "リポジトリのcloneに失敗しました: clone failed",
+    );
+  });
+
+  it("handles workspace.syncMain failure", async () => {
+    (workspace.syncMain as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("sync failed", "EXTERNAL_SERVICE_ERROR")),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "mainブランチの同期に失敗しました: sync failed",
+    );
+  });
+
+  it("handles workspace.createBranch failure", async () => {
+    (workspace.createBranch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("branch failed", "EXTERNAL_SERVICE_ERROR")),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "ブランチの作成に失敗しました: branch failed",
+    );
+  });
+});
+
+describe("InitCommand success flow", () => {
+  let redis: RedisClient;
+  let github: GitHubClient;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+  let command: InitCommand;
+
+  beforeEach(() => {
+    const vars = createCommand();
+    redis = vars.redis;
+    github = vars.github;
+    workspace = vars.workspace;
+    discordClient = vars.discordClient;
+    command = vars.command;
+    vi.restoreAllMocks();
+  });
+
+  it("fetches issue, clones repo, syncs main, creates branch, creates thread, saves state", async () => {
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(github.getIssue).toHaveBeenCalledWith("test-owner", "test-repo", 15);
+
+    expect(workspace.ensureClone).toHaveBeenCalledWith(
+      "https://github.com/test-owner/test-repo.git",
+      "test-repo-15",
+    );
+
+    expect(workspace.syncMain).toHaveBeenCalledWith("test-repo-15");
+
+    expect(workspace.createBranch).toHaveBeenCalledWith(
+      "test-repo-15",
+      "feature/15",
+    );
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "**Issue #15: Test Issue**\n\nbody",
+    );
+
+    expect(discordClient.createThreadFromMessage).toHaveBeenCalledWith(
+      "channel-1",
+      "msg-id",
+      "Issue #15: Test Issue",
+    );
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith("thread-id", {
+      initiatedBy: "user-1",
+      issueNumber: 15,
+      repo: "test-owner/test-repo",
+      branch: "feature/15",
+      workspacePath: "test-repo-15",
+      currentPhase: "init",
+      subStage: "idle",
+      lastError: null,
+      planOutput: null,
+    });
+  });
+});

--- a/src/bot/commands/develop/init.command.ts
+++ b/src/bot/commands/develop/init.command.ts
@@ -1,0 +1,241 @@
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+
+interface InitCommandDeps {
+  redis: RedisClient;
+  github: GitHubClient;
+  workspace: WorkspaceManager;
+  discordClient: DiscordClient;
+  githubOwner: string;
+  githubRepo: string;
+}
+
+export class InitCommand implements Command {
+  readonly name = "init";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "Issueから開発ワークフローを初期化",
+    options: [
+      {
+        name: "issue-number",
+        description: "Issue番号",
+        type: 4 as const,
+        required: true,
+      },
+    ],
+  };
+
+  constructor(private readonly deps: InitCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "InitCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async validate(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<{ issueNumber: number } | null> {
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+    const userId = interaction.userId;
+
+    const issueNumber = Number(interaction.options?.["issue-number"]);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "Issue番号は正の整数で指定してください。",
+      );
+      return null;
+    }
+
+    const inThread = await discordClient.isThreadChannel(channelId);
+    if (inThread) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "このコマンドはスレッド外のチャンネルで実行してください。",
+      );
+      return null;
+    }
+
+    const existingState = await redis.getThreadState(channelId);
+    if (existingState && existingState.subStage === "running") {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "現在別の処理が実行中です。完了してから再試行してください。",
+      );
+      return null;
+    }
+
+    if (existingState && existingState.initiatedBy !== userId) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "このワークフローは別のユーザーが初期化しました。",
+      );
+      return null;
+    }
+
+    return { issueNumber };
+  }
+
+  private async setupWorkspace(
+    interactionToken: string,
+    issueNumber: number,
+  ): Promise<{
+    branchName: string;
+    targetDir: string;
+  } | null> {
+    const { workspace, discordClient, githubOwner, githubRepo } = this.deps;
+    const branchName = `feature/${issueNumber}`;
+    const targetDir = `${githubRepo}-${issueNumber}`;
+    const repoUrl = `https://github.com/${githubOwner}/${githubRepo}.git`;
+
+    const cloneResult = await workspace.ensureClone(repoUrl, targetDir);
+    if (!cloneResult.ok) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `リポジトリのcloneに失敗しました: ${cloneResult.error.message}`,
+      );
+      return null;
+    }
+
+    const syncResult = await workspace.syncMain(targetDir);
+    if (!syncResult.ok) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `mainブランチの同期に失敗しました: ${syncResult.error.message}`,
+      );
+      return null;
+    }
+
+    const branchResult = await workspace.createBranch(targetDir, branchName);
+    if (!branchResult.ok) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `ブランチの作成に失敗しました: ${branchResult.error.message}`,
+      );
+      return null;
+    }
+
+    return { branchName, targetDir };
+  }
+
+  private async createThreadAndSaveState(options: {
+    interactionToken: string;
+    channelId: string;
+    userId: string;
+    issueNumber: number;
+    issue: import("@/infrastructure/github/github.client").IssueInfo;
+    ws: { branchName: string; targetDir: string };
+  }): Promise<void> {
+    const { interactionToken, channelId, userId, issueNumber, issue, ws } =
+      options;
+    const { redis, discordClient, githubOwner, githubRepo } = this.deps;
+    const log = getLogger();
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    const noBodyText = "(本文なし)";
+    const initMessage = `**Issue #${issueNumber}: ${issue.title}**\n\n${issue.body ? formatForDiscord(issue.body) : noBodyText}`;
+    const messageId = await discordClient.editInteractionResponse(
+      interactionToken,
+      initMessage,
+    );
+
+    let threadId = channelId;
+    if (messageId) {
+      const createdThreadId = await discordClient.createThreadFromMessage(
+        channelId,
+        messageId,
+        `Issue #${issueNumber}: ${issue.title}`.slice(0, 100),
+      );
+      if (createdThreadId) threadId = createdThreadId;
+    }
+
+    const initialState: ThreadState = {
+      initiatedBy: userId,
+      issueNumber,
+      repo: `${githubOwner}/${githubRepo}`,
+      branch: ws.branchName,
+      workspacePath: ws.targetDir,
+      currentPhase: "init",
+      subStage: "idle",
+      lastError: null,
+      planOutput: null,
+    };
+
+    await redis.saveThreadState(threadId, initialState);
+    log.info(
+      { threadId, issueNumber, branch: ws.branchName },
+      "InitCommand completed",
+    );
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const { github, discordClient, githubOwner, githubRepo } = this.deps;
+    const channelId = interaction.channelId;
+
+    const validated = await this.validate(interaction, interactionToken);
+    if (!validated) return;
+
+    const issueResult = await github.getIssue(
+      githubOwner,
+      githubRepo,
+      validated.issueNumber,
+    );
+    if (!issueResult.ok) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `Issue #${validated.issueNumber} の取得に失敗しました: ${issueResult.error.message}`,
+      );
+      return;
+    }
+
+    const ws = await this.setupWorkspace(
+      interactionToken,
+      validated.issueNumber,
+    );
+    if (!ws) return;
+
+    await this.createThreadAndSaveState({
+      interactionToken,
+      channelId,
+      userId: interaction.userId,
+      issueNumber: validated.issueNumber,
+      issue: issueResult.value,
+      ws,
+    });
+  }
+}

--- a/src/bot/commands/develop/plan.command.test.ts
+++ b/src/bot/commands/develop/plan.command.test.ts
@@ -1,0 +1,662 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { PlanCommand } from "./plan.command";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock("@/ai/prompts/templates/develop-plan", () => ({
+  buildDevelopPlanPrompt: vi.fn().mockReturnValue("plan-prompt"),
+}));
+
+vi.mock("./validate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./validate")>();
+  return {
+    validateThreadCommand: actual.validateThreadCommand,
+    executeCodexOrResume: vi.fn().mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    }),
+  };
+});
+
+vi.mock("@/shared/utils/format", () => ({
+  formatForDiscord: vi.fn((text: string) => `formatted:${text}`),
+}));
+
+// --- Mock factories ---
+
+function createMockRedisClient(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(null),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExecClient(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+function createMockGitHubClient(): GitHubClient {
+  return {
+    getIssue: vi.fn().mockResolvedValue(
+      ok({
+        number: 42,
+        title: "Test Issue",
+        body: "Issue body content",
+        owner: "owner",
+        repo: "repo",
+        state: "open",
+        labels: [],
+        assignees: [],
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+      }),
+    ),
+  } as unknown as GitHubClient;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+// --- Helpers ---
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "channel-1",
+    userId: "user-1",
+    commandName: "plan",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 42,
+    repo: "owner/repo",
+    branch: "feature/42",
+    workspacePath: "/workspace/feature-42",
+    currentPhase: "init",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+// --- Tests ---
+
+describe("PlanCommand properties", () => {
+  it("has name 'plan'", () => {
+    const command = new PlanCommand({
+      redis: createMockRedisClient(),
+      codexExec: createMockCodexExecClient(),
+      github: createMockGitHubClient(),
+      discordClient: createMockDiscordClient(),
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+    expect(command.name).toBe("plan");
+  });
+
+  it("has definition with description", () => {
+    const command = new PlanCommand({
+      redis: createMockRedisClient(),
+      codexExec: createMockCodexExecClient(),
+      github: createMockGitHubClient(),
+      discordClient: createMockDiscordClient(),
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+    expect(command.definition).toEqual({
+      description: "Issueに基づいて実装計画を作成",
+    });
+  });
+});
+
+describe("PlanCommand execute - token handling", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("returns deferred response on valid token", async () => {
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    const response = await command.execute(createInteraction());
+
+    // DeferredChannelMessageWithSource = 5
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error when no token", async () => {
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    // ChannelMessageWithSource = 4
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(64); // MessageFlags.Ephemeral
+  });
+});
+
+describe("PlanCommand execute - thread state validation", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("rejects if not in a thread channel", async () => {
+    (
+      discordClient.isThreadChannel as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(false);
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "このコマンドはスレッド内で実行してください。",
+    );
+  });
+
+  it("rejects if no thread state found", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "ワークフローが初期化されていません。先に `/init` を実行してください。",
+    );
+  });
+
+  it("rejects if wrong user (initiatedBy mismatch)", async () => {
+    const state = createMockThreadState({ initiatedBy: "other-user" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction({ userId: "user-1" }));
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "このワークフローの実行者のみが操作できます。",
+    );
+  });
+
+  it("rejects if wrong phase", async () => {
+    const state = createMockThreadState({ currentPhase: "developed" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "現在のフェーズが不正です (現在: developed, 期待: init または planned)",
+    );
+  });
+
+  it("rejects if subStage is running", async () => {
+    const state = createMockThreadState({ subStage: "running" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "現在別の処理が実行中です。完了してから再試行してください。",
+    );
+  });
+});
+
+describe("PlanCommand execute - github.getIssue failure", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("handles github.getIssue failure and responds with error", async () => {
+    const state = createMockThreadState();
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+    (github.getIssue as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new ExternalServiceError("GitHub", "API rate limit")),
+    );
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "Issue #42 の取得に失敗しました: GitHub: API rate limit",
+    );
+  });
+});
+
+describe("PlanCommand execute - success flow", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("validates, fetches issue, builds prompt, executes codex, updates state, responds", async () => {
+    const state = createMockThreadState();
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    // Ensure executeCodexOrResume mock resolves after restoreAllMocks
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    });
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    // Verify github.getIssue was called with correct args
+    expect(github.getIssue).toHaveBeenCalledWith("owner", "repo", 42);
+
+    // Verify buildDevelopPlanPrompt was called
+    const { buildDevelopPlanPrompt } = await import(
+      "@/ai/prompts/templates/develop-plan"
+    );
+    expect(buildDevelopPlanPrompt).toHaveBeenCalledWith({
+      issueBody: "Issue body content",
+      repo: "owner/repo",
+      branch: "feature/42",
+    });
+
+    // Verify executeCodexOrResume was called
+    expect(executeCodexOrResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "plan",
+        prompt: "plan-prompt",
+        cwd: "/workspace/feature-42",
+        sandboxMode: "read-only",
+      }),
+    );
+
+    // Verify compareAndSwapPhase was called with correct phases
+    expect(redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "channel-1",
+      "init",
+      "planned",
+    );
+
+    // Verify planOutput is saved in state
+    const savedState = (
+      redis.saveThreadState as ReturnType<typeof vi.fn>
+    ).mock.calls.at(-1)?.[1] as ThreadState | undefined;
+    expect(savedState?.planOutput).toBe("plan response");
+    expect(savedState?.subStage).toBe("idle");
+    // When CAS succeeds, state.currentPhase is not updated in memory;
+    // Redis CAS script handles the phase transition internally.
+    expect(savedState?.currentPhase).toBe("init");
+
+    // Verify discordClient.editInteractionResponse was called with formatted response
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "formatted:plan response",
+    );
+  });
+});
+
+describe("PlanCommand execute - error handling", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("catches codex execution errors and responds with error message", async () => {
+    const state = createMockThreadState();
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Codex timeout"),
+    );
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    // Verify state was reset with error info
+    const savedState = (
+      redis.saveThreadState as ReturnType<typeof vi.fn>
+    ).mock.calls.at(-1)?.[1] as ThreadState | undefined;
+    expect(savedState?.subStage).toBe("idle");
+    expect(savedState?.lastError).toBe("Codex timeout");
+
+    // Verify error response was sent
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "計画の作成中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+  });
+});
+
+describe("PlanCommand execute - compareAndSwapPhase verification", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("calls compareAndSwapPhase with current phase and 'planned'", async () => {
+    const state = createMockThreadState({ currentPhase: "init" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    // Ensure executeCodexOrResume mock resolves after restoreAllMocks
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    });
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "channel-1",
+      "init",
+      "planned",
+    );
+  });
+
+  it("calls compareAndSwapPhase with 'planned' phase when current is 'planned'", async () => {
+    const state = createMockThreadState({ currentPhase: "planned" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    // Ensure executeCodexOrResume mock resolves after restoreAllMocks
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    });
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "channel-1",
+      "planned",
+      "planned",
+    );
+  });
+
+  it("sets currentPhase to planned even when CAS fails", async () => {
+    const state = createMockThreadState({ currentPhase: "init" });
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+    (redis.compareAndSwapPhase as ReturnType<typeof vi.fn>).mockResolvedValue(
+      false,
+    );
+
+    // Ensure executeCodexOrResume mock resolves after restoreAllMocks
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "thread-1",
+      response: "plan response",
+      usage: null,
+    });
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    const savedState = (
+      redis.saveThreadState as ReturnType<typeof vi.fn>
+    ).mock.calls.at(-1)?.[1] as ThreadState | undefined;
+    expect(savedState?.currentPhase).toBe("planned");
+  });
+});
+
+describe("PlanCommand execute - planOutput saved in state", () => {
+  let redis: RedisClient;
+  let codexExec: CodexExecClient;
+  let github: GitHubClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    redis = createMockRedisClient();
+    codexExec = createMockCodexExecClient();
+    github = createMockGitHubClient();
+    discordClient = createMockDiscordClient();
+  });
+
+  it("saves codex response as planOutput in state", async () => {
+    const state = createMockThreadState();
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const { executeCodexOrResume } = await import("./validate");
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "thread-1",
+      response: "detailed plan output",
+      usage: null,
+    });
+
+    const command = new PlanCommand({
+      redis,
+      codexExec,
+      github,
+      discordClient,
+      githubOwner: "owner",
+      githubRepo: "repo",
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    const savedState = (
+      redis.saveThreadState as ReturnType<typeof vi.fn>
+    ).mock.calls.at(-1)?.[1] as ThreadState | undefined;
+    expect(savedState?.planOutput).toBe("detailed plan output");
+  });
+});

--- a/src/bot/commands/develop/plan.command.ts
+++ b/src/bot/commands/develop/plan.command.ts
@@ -1,0 +1,165 @@
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import { buildDevelopPlanPrompt } from "@/ai/prompts/templates/develop-plan";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { Phase } from "@/infrastructure/redis/thread-state.types";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+interface PlanCommandDeps {
+  redis: RedisClient;
+  codexExec: CodexExecClient;
+  github: GitHubClient;
+  discordClient: DiscordClient;
+  githubOwner: string;
+  githubRepo: string;
+}
+
+const ALLOWED_PHASES: Phase[] = ["init", "planned"];
+
+export class PlanCommand implements Command {
+  readonly name = "plan";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "Issueに基づいて実装計画を作成",
+  };
+
+  constructor(private readonly deps: PlanCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "PlanCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async executePlan(
+    state: import("@/infrastructure/redis/thread-state.types").ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, codexExec, github, discordClient, githubOwner, githubRepo } =
+      this.deps;
+
+    const issueResult = await github.getIssue(
+      githubOwner,
+      githubRepo,
+      state.issueNumber,
+    );
+    if (!issueResult.ok) {
+      await this.handleError(
+        channelId,
+        state,
+        interactionToken,
+        `Issue #${state.issueNumber} の取得に失敗しました: ${issueResult.error.message}`,
+      );
+      return;
+    }
+
+    const prompt = buildDevelopPlanPrompt({
+      issueBody: issueResult.value.body ?? "",
+      repo: state.repo,
+      branch: state.branch,
+    });
+    const codexResult = await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId,
+      phase: "plan",
+      prompt,
+      cwd: state.workspacePath,
+      sandboxMode: "read-only",
+    });
+
+    state.planOutput = codexResult.response;
+    state.subStage = "idle";
+    const casSuccess = await redis.compareAndSwapPhase(
+      channelId,
+      state.currentPhase,
+      "planned",
+    );
+    if (!casSuccess) state.currentPhase = "planned";
+    await redis.saveThreadState(channelId, state);
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      formatForDiscord(codexResult.response),
+    );
+    log.info(
+      { channelId, issueNumber: state.issueNumber },
+      "PlanCommand completed",
+    );
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ALLOWED_PHASES,
+      interactionToken,
+    });
+    if (!result) return;
+
+    const state = result.state;
+    state.subStage = "running";
+    await redis.saveThreadState(channelId, state);
+
+    try {
+      await this.executePlan(state, channelId, interactionToken);
+    } catch (err) {
+      const log = getLogger();
+      log.error({ err: String(err) }, "PlanCommand error");
+      state.subStage = "idle";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "計画の作成中にエラーが発生しました。しばらくしてから再試行してください。",
+      );
+    }
+  }
+
+  private async handleError(
+    channelId: string,
+    state: import("@/infrastructure/redis/thread-state.types").ThreadState,
+    interactionToken: string,
+    errorMessage: string,
+  ): Promise<void> {
+    const { redis, discordClient } = this.deps;
+    state.subStage = "idle";
+    state.lastError = errorMessage;
+    await redis.saveThreadState(channelId, state);
+    await discordClient.editInteractionResponse(interactionToken, errorMessage);
+  }
+}

--- a/src/bot/commands/develop/pr.command.test.ts
+++ b/src/bot/commands/develop/pr.command.test.ts
@@ -1,0 +1,310 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { PrCommand } from "./pr.command";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "thread-1",
+    userId: "user-1",
+    commandName: "pr",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 15,
+    repo: "test-repo",
+    branch: "feature/15",
+    workspacePath: "/workspace/test-repo",
+    currentPhase: "committed",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function createMockRedisClient(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExecClient(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "push response",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "push response",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+function createMockGitHubClient(): GitHubClient {
+  return {
+    getIssue: vi.fn().mockResolvedValue(
+      ok({
+        number: 15,
+        title: "Test",
+        body: "body",
+        owner: "o",
+        repo: "r",
+        state: "open",
+        labels: [],
+        assignees: [],
+        createdAt: "",
+        updatedAt: "",
+      }),
+    ),
+    createPullRequest: vi
+      .fn()
+      .mockResolvedValue(
+        ok({ url: "https://github.com/o/r/pull/1", number: 1 }),
+      ),
+  } as unknown as GitHubClient;
+}
+
+function createMockWorkspaceManager(): WorkspaceManager {
+  return {} as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+function createCommandDeps() {
+  return {
+    redis: createMockRedisClient(),
+    codexExec: createMockCodexExecClient(),
+    workspace: createMockWorkspaceManager(),
+    github: createMockGitHubClient(),
+    discordClient: createMockDiscordClient(),
+    githubOwner: "o",
+    githubRepo: "r",
+  };
+}
+
+describe("PrCommand properties", () => {
+  it("has name 'pr'", () => {
+    const command = new PrCommand(createCommandDeps());
+    expect(command.name).toBe("pr");
+  });
+});
+
+describe("PrCommand deferred response", () => {
+  let command: PrCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new PrCommand(deps);
+  });
+
+  it("returns deferred response immediately", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("PrCommand validates thread", () => {
+  let command: PrCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new PrCommand(deps);
+  });
+
+  it("requires phase 'committed'", async () => {
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.codexExec.startThread).toHaveBeenCalled();
+  });
+
+  it("rejects when phase is wrong", async () => {
+    deps.redis.getThreadState = vi
+      .fn()
+      .mockResolvedValue(createMockThreadState({ currentPhase: "tested" }));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "現在のフェーズが不正です (現在: tested, 期待: committed)",
+    );
+    expect(deps.codexExec.startThread).not.toHaveBeenCalled();
+  });
+});
+
+describe("PrCommand success flow", () => {
+  let command: PrCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new PrCommand(deps);
+  });
+
+  it("pushes branch via codex, creates PR on GitHub, updates phase to completed, responds with PR URL", async () => {
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    // Push branch via codex
+    expect(deps.codexExec.startThread).toHaveBeenCalledWith(
+      expect.stringContaining("git push -u origin HEAD"),
+      expect.objectContaining({
+        cwd: "/workspace/test-repo",
+        sandboxMode: "write",
+      }),
+    );
+
+    // Fetches issue for title
+    expect(deps.github.getIssue).toHaveBeenCalledWith("o", "r", 15);
+
+    // Creates PR on GitHub
+    expect(deps.github.createPullRequest).toHaveBeenCalledWith("o", "r", {
+      title: "Test",
+      body: "Closes #15\n\nbody",
+      head: "feature/15",
+      base: "main",
+    });
+
+    // Updates phase to completed
+    expect(deps.redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "thread-1",
+      "committed",
+      "completed",
+    );
+
+    // Saves thread state
+    expect(deps.redis.saveThreadState).toHaveBeenCalled();
+
+    // Responds with PR URL
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      expect.stringContaining("https://github.com/o/r/pull/1"),
+    );
+  });
+});
+
+describe("PrCommand PR creation failure", () => {
+  let command: PrCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new PrCommand(deps);
+  });
+
+  it("handles error when PR creation fails", async () => {
+    deps.github.createPullRequest = vi
+      .fn()
+      .mockResolvedValue(err(new AppError("PR already exists", "PR_ERROR")));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "PRの作成に失敗しました: PR already exists",
+    );
+
+    expect(deps.redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "PR already exists",
+      }),
+    );
+  });
+});
+
+describe("PrCommand codex push failure", () => {
+  let command: PrCommand;
+  let deps: ReturnType<typeof createCommandDeps>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    deps = createCommandDeps();
+    command = new PrCommand(deps);
+  });
+
+  it("handles error when codex push fails", async () => {
+    deps.codexExec.startThread = vi
+      .fn()
+      .mockRejectedValue(new Error("push failed"));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(deps.discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "PR作成中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+
+    expect(deps.redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "push failed",
+      }),
+    );
+  });
+});

--- a/src/bot/commands/develop/pr.command.ts
+++ b/src/bot/commands/develop/pr.command.ts
@@ -1,0 +1,214 @@
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { GitHubClient } from "@/infrastructure/github/github.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+interface PrCommandDeps {
+  redis: RedisClient;
+  codexExec: CodexExecClient;
+  github: GitHubClient;
+  workspace: WorkspaceManager;
+  discordClient: DiscordClient;
+  githubOwner: string;
+  githubRepo: string;
+}
+
+export class PrCommand implements Command {
+  readonly name = "pr";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "プルリクエストを作成",
+  };
+
+  constructor(private readonly deps: PrCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "PrCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async pushBranch(
+    state: ThreadState,
+    channelId: string,
+  ): Promise<void> {
+    const { redis, codexExec } = this.deps;
+    const pushPrompt = [
+      // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+      "現在のブランチをリモートにプッシュしてください。",
+      // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+      "以下のコマンドを実行してください:",
+      "git push -u origin HEAD",
+    ].join("\n");
+
+    await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId,
+      phase: "pr",
+      prompt: pushPrompt,
+      cwd: state.workspacePath,
+      sandboxMode: "write",
+    });
+  }
+
+  private async createPullRequest(
+    state: ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const { github, githubOwner, githubRepo } = this.deps;
+
+    const issueResult = await github.getIssue(
+      githubOwner,
+      githubRepo,
+      state.issueNumber,
+    );
+    const issueTitle = issueResult.ok
+      ? issueResult.value.title
+      : `Issue #${state.issueNumber}`;
+    const issueBody = issueResult.ok ? (issueResult.value.body ?? "") : "";
+
+    const prResult = await github.createPullRequest(githubOwner, githubRepo, {
+      title: issueTitle,
+      body: `Closes #${state.issueNumber}\n\n${issueBody}`,
+      head: state.branch,
+      base: "main",
+    });
+
+    if (!prResult.ok) {
+      await this.handlePrFailure(
+        state,
+        channelId,
+        interactionToken,
+        prResult.error.message,
+      );
+      return;
+    }
+
+    await this.finalizePr(
+      state,
+      channelId,
+      interactionToken,
+      prResult.value.url,
+    );
+  }
+
+  private async handlePrFailure(
+    state: ThreadState,
+    channelId: string,
+    interactionToken: string,
+    errorMessage: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, discordClient } = this.deps;
+    log.error({ error: errorMessage }, "Failed to create PR");
+    state.subStage = "idle";
+    state.lastError = errorMessage;
+    await redis.saveThreadState(channelId, state);
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      `PRの作成に失敗しました: ${errorMessage}`,
+    );
+  }
+
+  private async finalizePr(
+    state: ThreadState,
+    channelId: string,
+    interactionToken: string,
+    prUrl: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, discordClient } = this.deps;
+    state.subStage = "idle";
+    const casSuccess = await redis.compareAndSwapPhase(
+      channelId,
+      "committed",
+      "completed",
+    );
+    if (!casSuccess) state.currentPhase = "completed";
+
+    await redis.saveThreadState(channelId, state);
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      formatForDiscord(`PRを作成しました: ${prUrl}`),
+    );
+
+    log.info(
+      { channelId, issueNumber: state.issueNumber, prUrl },
+      "PrCommand completed",
+    );
+  }
+
+  private async executePr(
+    state: ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    await this.pushBranch(state, channelId);
+    await this.createPullRequest(state, channelId, interactionToken);
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const vr = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ["committed"],
+      interactionToken,
+    });
+    if (!vr) return;
+
+    const state = vr.state;
+    state.subStage = "running";
+    await redis.saveThreadState(channelId, state);
+
+    try {
+      await this.executePr(state, channelId, interactionToken);
+    } catch (err) {
+      log.error({ err: String(err) }, "PrCommand error");
+      state.subStage = "idle";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "PR作成中にエラーが発生しました。しばらくしてから再試行してください。",
+      );
+    }
+  }
+}

--- a/src/bot/commands/develop/reset.command.test.ts
+++ b/src/bot/commands/develop/reset.command.test.ts
@@ -1,0 +1,251 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type {
+  Phase,
+  ThreadState,
+} from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { ResetCommand } from "./reset.command";
+import { validateThreadCommand } from "./validate";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("./validate", () => ({
+  validateThreadCommand: vi.fn(),
+}));
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "thread-1",
+    userId: "user-1",
+    commandName: "reset",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 42,
+    repo: "owner/repo",
+    branch: "feature/42",
+    workspacePath: "/workspace/issue-42",
+    currentPhase: "developed",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function createMockRedis(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockWorkspace(): WorkspaceManager {
+  return {
+    discardChanges: vi.fn().mockResolvedValue(ok(undefined)),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+    sendMessage: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("ResetCommand properties", () => {
+  it("has name 'reset'", () => {
+    const command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.name).toBe("reset");
+  });
+
+  it("has definition with description", () => {
+    const command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.definition).toEqual({
+      description: "ワークスペースの変更を破棄",
+    });
+  });
+});
+
+describe("ResetCommand deferred response", () => {
+  let command: ResetCommand;
+
+  beforeEach(() => {
+    command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("returns deferred response immediately", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("ResetCommand thread validation", () => {
+  let command: ResetCommand;
+
+  beforeEach(() => {
+    command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("accepts any phase", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(validateThreadCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedPhases: [
+          "init",
+          "planned",
+          "developed",
+          "tested",
+          "committed",
+          "completed",
+        ] as Phase[],
+      }),
+    );
+  });
+
+  it("does nothing when validateThreadCommand returns null", async () => {
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    const workspace = createMockWorkspace();
+    expect(workspace.discardChanges).not.toHaveBeenCalled();
+  });
+});
+
+describe("ResetCommand success flow", () => {
+  let command: ResetCommand;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    workspace = createMockWorkspace();
+    discordClient = createMockDiscordClient();
+    command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("discards changes and responds with success message", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(workspace.discardChanges).toHaveBeenCalledWith(
+      "/workspace/issue-42",
+    );
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "ワークスペースの変更を破棄しました。",
+    );
+  });
+});
+
+describe("ResetCommand error when discard fails", () => {
+  let command: ResetCommand;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    discordClient = createMockDiscordClient();
+    const workspace = createMockWorkspace();
+    (workspace.discardChanges as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("git checkout failed", "GIT_ERROR")),
+    );
+    command = new ResetCommand({
+      redis: createMockRedis(),
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("responds with error message when discardChanges fails", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "変更の破棄に失敗しました: git checkout failed",
+    );
+  });
+});

--- a/src/bot/commands/develop/reset.command.ts
+++ b/src/bot/commands/develop/reset.command.ts
@@ -1,0 +1,99 @@
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { Phase } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { validateThreadCommand } from "./validate";
+
+interface ResetCommandDeps {
+  redis: RedisClient;
+  workspace: WorkspaceManager;
+  discordClient: DiscordClient;
+}
+
+const ALL_PHASES: Phase[] = [
+  "init",
+  "planned",
+  "developed",
+  "tested",
+  "committed",
+  "completed",
+];
+
+export class ResetCommand implements Command {
+  readonly name = "reset";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "ワークスペースの変更を破棄",
+  };
+
+  constructor(private readonly deps: ResetCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "ResetCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, workspace, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const vr = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ALL_PHASES,
+      interactionToken,
+    });
+    if (!vr) return;
+
+    const discardResult = await workspace.discardChanges(
+      vr.state.workspacePath,
+    );
+    if (!discardResult.ok) {
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        `変更の破棄に失敗しました: ${discardResult.error.message}`,
+      );
+      return;
+    }
+
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+      "ワークスペースの変更を破棄しました。",
+    );
+
+    log.info(
+      { channelId, issueNumber: vr.state.issueNumber },
+      "ResetCommand completed",
+    );
+  }
+}

--- a/src/bot/commands/develop/test.command.test.ts
+++ b/src/bot/commands/develop/test.command.test.ts
@@ -1,0 +1,491 @@
+import { MessageFlags } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { AppError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { TestCommand } from "./test.command";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("@/ai/prompts/templates/develop-test", () => ({
+  buildDevelopTestPrompt: vi.fn().mockReturnValue("built-test-prompt"),
+}));
+
+vi.mock("./validate", () => ({
+  validateThreadCommand: vi.fn(),
+  executeCodexOrResume: vi.fn(),
+}));
+
+function createInteraction(
+  overrides: Partial<DomainInteraction> = {},
+): DomainInteraction {
+  return {
+    id: "test-id",
+    type: "command",
+    channelId: "thread-1",
+    userId: "user-1",
+    commandName: "test",
+    options: {},
+    raw: { token: "test-token" },
+    ...overrides,
+  };
+}
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-1",
+    issueNumber: 42,
+    repo: "owner/repo",
+    branch: "feature/42",
+    workspacePath: "/workspace/issue-42",
+    currentPhase: "developed",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function createMockRedis(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    saveThreadState: vi.fn().mockResolvedValue(undefined),
+    compareAndSwapPhase: vi.fn().mockResolvedValue(true),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExec(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "response text",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "response text",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+function createMockWorkspace(): WorkspaceManager {
+  return {
+    getDiff: vi.fn().mockResolvedValue(ok("diff content")),
+  } as unknown as WorkspaceManager;
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+    sendMessage: vi.fn().mockResolvedValue(true),
+  } as unknown as DiscordClient;
+}
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("TestCommand properties", () => {
+  it("has name 'test'", () => {
+    const command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.name).toBe("test");
+  });
+
+  it("has definition with description", () => {
+    const command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    expect(command.definition).toEqual({
+      description: "実装に対するテストを作成・実行",
+    });
+  });
+});
+
+describe("TestCommand deferred response", () => {
+  let command: TestCommand;
+
+  beforeEach(() => {
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("returns deferred response immediately", async () => {
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("TestCommand thread validation", () => {
+  let command: TestCommand;
+
+  beforeEach(() => {
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("validates thread with expected phase 'developed'", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(validateThreadCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedPhases: ["developed"],
+      }),
+    );
+  });
+
+  it("does nothing when validateThreadCommand returns null (wrong phase)", async () => {
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockClear();
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(executeCodexOrResume).not.toHaveBeenCalled();
+  });
+});
+
+describe("TestCommand success flow - execution steps", () => {
+  let command: TestCommand;
+  let redis: RedisClient;
+  let workspace: WorkspaceManager;
+
+  beforeEach(() => {
+    redis = createMockRedis();
+    workspace = createMockWorkspace();
+    command = new TestCommand({
+      redis,
+      codexExec: createMockCodexExec(),
+      workspace,
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("gets diff, builds prompt, executes codex, gets post-diff, updates phase to 'tested'", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex test response",
+      usage: null,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(workspace.getDiff).toHaveBeenCalledWith("/workspace/issue-42");
+    expect(workspace.getDiff).toHaveBeenCalledTimes(2);
+
+    expect(executeCodexOrResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "test",
+        prompt: "built-test-prompt",
+        cwd: "/workspace/issue-42",
+        sandboxMode: "write",
+      }),
+    );
+
+    expect(redis.compareAndSwapPhase).toHaveBeenCalledWith(
+      "thread-1",
+      "developed",
+      "tested",
+    );
+    expect(redis.saveThreadState).toHaveBeenCalledWith("thread-1", state);
+  });
+});
+
+describe("TestCommand success flow - diff response", () => {
+  let command: TestCommand;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    discordClient = createMockDiscordClient();
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("sends diff when post-diff is available", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex test response",
+      usage: null,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "**テスト作成完了**\n\n```diff\ndiff content\n```",
+    );
+  });
+});
+
+describe("TestCommand success flow - empty diff fallback", () => {
+  let command: TestCommand;
+  let workspace: WorkspaceManager;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    workspace = createMockWorkspace();
+    discordClient = createMockDiscordClient();
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("uses codex response text when post-diff is empty", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockResolvedValue({
+      threadId: "codex-thread-1",
+      response: "codex test response",
+      usage: null,
+    });
+    (workspace.getDiff as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(ok("initial diff"))
+      .mockResolvedValueOnce(ok(""));
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "codex test response",
+    );
+  });
+});
+
+describe("TestCommand error when diff fetch fails", () => {
+  let redis: RedisClient;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    redis = createMockRedis();
+    discordClient = createMockDiscordClient();
+    vi.restoreAllMocks();
+  });
+
+  it("handles error when initial diff fetch fails", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    const workspace = createMockWorkspace();
+    (workspace.getDiff as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("diff failed", "GIT_ERROR")),
+    );
+    const cmd = new TestCommand({
+      redis,
+      codexExec: createMockCodexExec(),
+      workspace,
+      discordClient,
+    });
+
+    await cmd.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "diffの取得に失敗しました: diff failed",
+      }),
+    );
+  });
+});
+
+describe("TestCommand error when diff fetch fails - discord response", () => {
+  let command: TestCommand;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    discordClient = createMockDiscordClient();
+    const workspace = createMockWorkspace();
+    (workspace.getDiff as ReturnType<typeof vi.fn>).mockResolvedValue(
+      err(new AppError("diff failed", "GIT_ERROR")),
+    );
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace,
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("sends error message to discord when diff fetch fails", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "テスト作成中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+  });
+});
+
+describe("TestCommand error handling - state update", () => {
+  let command: TestCommand;
+  let redis: RedisClient;
+
+  beforeEach(() => {
+    redis = createMockRedis();
+    command = new TestCommand({
+      redis,
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient: createMockDiscordClient(),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("handles codex execution failure", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AppError("codex test failed", "CODEX_ERROR"),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        subStage: "idle",
+        lastError: "codex test failed",
+      }),
+    );
+  });
+
+  it("handles non-Error thrown value in codex execution", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      "string error",
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(redis.saveThreadState).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({
+        lastError: "string error",
+      }),
+    );
+  });
+});
+
+describe("TestCommand error handling - discord response", () => {
+  let command: TestCommand;
+  let discordClient: DiscordClient;
+
+  beforeEach(() => {
+    discordClient = createMockDiscordClient();
+    command = new TestCommand({
+      redis: createMockRedis(),
+      codexExec: createMockCodexExec(),
+      workspace: createMockWorkspace(),
+      discordClient,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("sends error message to discord on codex failure", async () => {
+    const state = createMockThreadState();
+    (validateThreadCommand as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state,
+    });
+    (executeCodexOrResume as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new AppError("codex test failed", "CODEX_ERROR"),
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "test-token",
+      "テスト作成中にエラーが発生しました。しばらくしてから再試行してください。",
+    );
+  });
+});

--- a/src/bot/commands/develop/test.command.ts
+++ b/src/bot/commands/develop/test.command.ts
@@ -1,0 +1,152 @@
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import { buildDevelopTestPrompt } from "@/ai/prompts/templates/develop-test";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { WorkspaceManager } from "@/infrastructure/workspace/workspace.manager";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+interface TestCommandDeps {
+  redis: RedisClient;
+  codexExec: CodexExecClient;
+  workspace: WorkspaceManager;
+  discordClient: DiscordClient;
+}
+
+export class TestCommand implements Command {
+  readonly name = "test";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "実装に対するテストを作成・実行",
+  };
+
+  constructor(private readonly deps: TestCommandDeps) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction, token).catch((err) => {
+      log.error({ err: String(err) }, "TestCommand background error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async runCodexTest(
+    state: ThreadState,
+    channelId: string,
+  ): Promise<import("@/ai/client/codex-exec.client").CodexExecResult> {
+    const { redis, codexExec, workspace } = this.deps;
+
+    const diffResult = await workspace.getDiff(state.workspacePath);
+    if (!diffResult.ok) {
+      throw new Error(`diffの取得に失敗しました: ${diffResult.error.message}`);
+    }
+
+    const prompt = buildDevelopTestPrompt({
+      diff: diffResult.value,
+      repo: state.repo,
+      branch: state.branch,
+    });
+
+    return executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId,
+      phase: "test",
+      prompt,
+      cwd: state.workspacePath,
+      sandboxMode: "write",
+    });
+  }
+
+  private async executeTest(
+    state: ThreadState,
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, workspace, discordClient } = this.deps;
+
+    const codexResult = await this.runCodexTest(state, channelId);
+
+    const postDiffResult = await workspace.getDiff(state.workspacePath);
+    const postDiffText = postDiffResult.ok ? postDiffResult.value : "";
+
+    state.subStage = "idle";
+    const casSuccess = await redis.compareAndSwapPhase(
+      channelId,
+      "developed",
+      "tested",
+    );
+    if (!casSuccess) state.currentPhase = "tested";
+
+    await redis.saveThreadState(channelId, state);
+
+    const responseText = postDiffText
+      ? `**テスト作成完了**\n\n\`\`\`diff\n${formatForDiscord(postDiffText)}\n\`\`\``
+      : formatForDiscord(codexResult.response);
+    await discordClient.editInteractionResponse(interactionToken, responseText);
+
+    log.info(
+      { channelId, issueNumber: state.issueNumber },
+      "TestCommand completed",
+    );
+  }
+
+  private async processInBackground(
+    interaction: DomainInteraction,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+    const { redis, discordClient } = this.deps;
+    const channelId = interaction.channelId;
+
+    const vr = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId,
+      userId: interaction.userId,
+      expectedPhases: ["developed"],
+      interactionToken,
+    });
+    if (!vr) return;
+
+    const state = vr.state;
+    state.subStage = "running";
+    await redis.saveThreadState(channelId, state);
+
+    try {
+      await this.executeTest(state, channelId, interactionToken);
+    } catch (err) {
+      log.error({ err: String(err) }, "TestCommand error");
+      state.subStage = "idle";
+      state.lastError = err instanceof Error ? err.message : String(err);
+      await redis.saveThreadState(channelId, state);
+      await discordClient.editInteractionResponse(
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "テスト作成中にエラーが発生しました。しばらくしてから再試行してください。",
+      );
+    }
+  }
+}

--- a/src/bot/commands/develop/validate.test.ts
+++ b/src/bot/commands/develop/validate.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexExecClient } from "@/ai/client/codex-exec.client";
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type { ThreadState } from "@/infrastructure/redis/thread-state.types";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+import { executeCodexOrResume, validateThreadCommand } from "./validate";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function createMockThreadState(
+  overrides: Partial<ThreadState> = {},
+): ThreadState {
+  return {
+    initiatedBy: "user-123",
+    issueNumber: 42,
+    repo: "owner/repo",
+    branch: "feature/test",
+    workspacePath: "/workspace/repo",
+    currentPhase: "planned",
+    subStage: "idle",
+    lastError: null,
+    planOutput: null,
+    ...overrides,
+  };
+}
+
+function createMockDiscordClient(): DiscordClient {
+  return {
+    isThreadChannel: vi.fn().mockResolvedValue(true),
+    editInteractionResponse: vi.fn().mockResolvedValue(undefined),
+  } as unknown as DiscordClient;
+}
+
+function createMockRedisClient(): RedisClient {
+  return {
+    getThreadState: vi.fn().mockResolvedValue(createMockThreadState()),
+    getCodexThread: vi.fn().mockResolvedValue(null),
+    saveCodexThread: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RedisClient;
+}
+
+function createMockCodexExecClient(): CodexExecClient {
+  return {
+    startThread: vi.fn().mockResolvedValue({
+      response: "done",
+      threadId: "thread-new",
+      usage: null,
+    }),
+    resumeThread: vi.fn().mockResolvedValue({
+      response: "resumed",
+      threadId: "thread-existing",
+      usage: null,
+    }),
+  } as unknown as CodexExecClient;
+}
+
+describe("validateThreadCommand", () => {
+  let discordClient: DiscordClient;
+  let redis: RedisClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    discordClient = createMockDiscordClient();
+    redis = createMockRedisClient();
+  });
+
+  it("returns null when not in thread (edits response)", async () => {
+    (
+      discordClient.isThreadChannel as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(false);
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-123",
+      expectedPhases: ["planned"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toBeNull();
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "token-abc",
+      "このコマンドはスレッド内で実行してください。",
+    );
+  });
+
+  it("returns null when no thread state exists", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-123",
+      expectedPhases: ["planned"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toBeNull();
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "token-abc",
+      "ワークフローが初期化されていません。先に `/init` を実行してください。",
+    );
+  });
+
+  it("returns null when userId doesn't match initiatedBy", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockThreadState({ initiatedBy: "user-123" }),
+    );
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-456",
+      expectedPhases: ["planned"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toBeNull();
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "token-abc",
+      "このワークフローの実行者のみが操作できます。",
+    );
+  });
+
+  it("returns null when phase is not in expectedPhases", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockThreadState({ currentPhase: "init" }),
+    );
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-123",
+      expectedPhases: ["planned", "developed"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toBeNull();
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "token-abc",
+      "現在のフェーズが不正です (現在: init, 期待: planned または developed)",
+    );
+  });
+
+  it("returns null when subStage is running", async () => {
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockThreadState({ subStage: "running" }),
+    );
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-123",
+      expectedPhases: ["planned"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toBeNull();
+    expect(discordClient.editInteractionResponse).toHaveBeenCalledWith(
+      "token-abc",
+      "現在別の処理が実行中です。完了してから再試行してください。",
+    );
+  });
+
+  it("returns state when all validations pass", async () => {
+    const state = createMockThreadState();
+    (redis.getThreadState as ReturnType<typeof vi.fn>).mockResolvedValue(state);
+
+    const result = await validateThreadCommand({
+      discordClient,
+      redis,
+      channelId: "channel-1",
+      userId: "user-123",
+      expectedPhases: ["planned"],
+      interactionToken: "token-abc",
+    });
+
+    expect(result).toEqual({ state });
+    expect(discordClient.editInteractionResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe("executeCodexOrResume", () => {
+  let codexExec: CodexExecClient;
+  let redis: RedisClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    codexExec = createMockCodexExecClient();
+    redis = createMockRedisClient();
+  });
+
+  it("calls startThread when no existing thread ID", async () => {
+    (redis.getCodexThread as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const result = await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId: "channel-1",
+      phase: "develop",
+      prompt: "implement feature",
+      cwd: "/workspace/repo",
+      sandboxMode: "write",
+    });
+
+    expect(codexExec.startThread).toHaveBeenCalledWith("implement feature", {
+      prompt: "implement feature",
+      cwd: "/workspace/repo",
+      sandboxMode: "write",
+    });
+    expect(codexExec.resumeThread).not.toHaveBeenCalled();
+    expect(result.threadId).toBe("thread-new");
+    expect(result.response).toBe("done");
+  });
+
+  it("calls resumeThread when existing thread ID exists", async () => {
+    (redis.getCodexThread as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "thread-old",
+    );
+
+    const result = await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId: "channel-1",
+      phase: "develop",
+      prompt: "continue feature",
+      cwd: "/workspace/repo",
+      sandboxMode: "write",
+    });
+
+    expect(codexExec.resumeThread).toHaveBeenCalledWith(
+      "thread-old",
+      "continue feature",
+      {
+        prompt: "continue feature",
+        cwd: "/workspace/repo",
+        sandboxMode: "write",
+      },
+    );
+    expect(codexExec.startThread).not.toHaveBeenCalled();
+    expect(result.threadId).toBe("thread-existing");
+    expect(result.response).toBe("resumed");
+  });
+
+  it("saves codex thread ID after execution", async () => {
+    (redis.getCodexThread as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await executeCodexOrResume({
+      codexExec,
+      redis,
+      channelId: "channel-1",
+      phase: "develop",
+      prompt: "implement feature",
+      cwd: "/workspace/repo",
+      sandboxMode: "write",
+    });
+
+    expect(redis.saveCodexThread).toHaveBeenCalledWith(
+      "channel-1",
+      "develop",
+      "thread-new",
+    );
+  });
+});

--- a/src/bot/commands/develop/validate.ts
+++ b/src/bot/commands/develop/validate.ts
@@ -1,0 +1,105 @@
+import type { RedisClient } from "@/infrastructure/redis/redis.client";
+import type {
+  Phase,
+  ThreadState,
+} from "@/infrastructure/redis/thread-state.types";
+import type { DiscordClient } from "@/sdk/discord/discord.client";
+
+export interface ValidationResult {
+  state: ThreadState;
+}
+
+export interface ValidateThreadOptions {
+  discordClient: DiscordClient;
+  redis: RedisClient;
+  channelId: string;
+  userId: string;
+  expectedPhases: Phase[];
+  interactionToken: string;
+}
+
+export async function validateThreadCommand(
+  options: ValidateThreadOptions,
+): Promise<ValidationResult | null> {
+  const {
+    discordClient,
+    redis,
+    channelId,
+    userId,
+    expectedPhases,
+    interactionToken,
+  } = options;
+  const inThread = await discordClient.isThreadChannel(channelId);
+  if (!inThread) {
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+      "このコマンドはスレッド内で実行してください。",
+    );
+    return null;
+  }
+
+  const state = await redis.getThreadState(channelId);
+  if (!state) {
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+      "ワークフローが初期化されていません。先に `/init` を実行してください。",
+    );
+    return null;
+  }
+
+  if (state.initiatedBy !== userId) {
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+      "このワークフローの実行者のみが操作できます。",
+    );
+    return null;
+  }
+
+  if (!expectedPhases.includes(state.currentPhase)) {
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      `現在のフェーズが不正です (現在: ${state.currentPhase}, 期待: ${expectedPhases.join(" または ")})`,
+    );
+    return null;
+  }
+
+  if (state.subStage === "running") {
+    await discordClient.editInteractionResponse(
+      interactionToken,
+      // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+      "現在別の処理が実行中です。完了してから再試行してください。",
+    );
+    return null;
+  }
+
+  return { state };
+}
+
+export interface ExecuteCodexOptions {
+  codexExec: import("@/ai/client/codex-exec.client").CodexExecClient;
+  redis: RedisClient;
+  channelId: string;
+  phase: string;
+  prompt: string;
+  cwd: string;
+  sandboxMode: "read-only" | "write";
+}
+
+export async function executeCodexOrResume(
+  options: ExecuteCodexOptions,
+): Promise<import("@/ai/client/codex-exec.client").CodexExecResult> {
+  const { codexExec, redis, channelId, phase, prompt, cwd, sandboxMode } =
+    options;
+  const existingThreadId = await redis.getCodexThread(channelId, phase);
+  const execOptions = { prompt, cwd, sandboxMode };
+
+  const result = existingThreadId
+    ? await codexExec.resumeThread(existingThreadId, prompt, execOptions)
+    : await codexExec.startThread(prompt, execOptions);
+
+  await redis.saveCodexThread(channelId, phase, result.threadId);
+  return result;
+}

--- a/src/bot/handlers/interaction.handler.test.ts
+++ b/src/bot/handlers/interaction.handler.test.ts
@@ -115,7 +115,6 @@ describe("InteractionHandler command not found", () => {
     );
 
     expect(response.type).toBe(4);
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(response.data?.content).toBe("不明なコマンドです");
     expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
   });
@@ -125,7 +124,6 @@ describe("InteractionHandler command not found", () => {
       createInteraction({ commandName: undefined }),
     );
 
-    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
     expect(response.data?.content).toBe("不明なコマンドです");
   });
 });
@@ -145,7 +143,6 @@ describe("InteractionHandler command execution error", () => {
 
     expect(response.type).toBe(4);
     expect(response.data?.content).toBe(
-      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       "エラーが発生しました。しばらくしてからお試しください。",
     );
     expect(response.data?.flags).toBe(MessageFlags.Ephemeral);

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -268,7 +268,6 @@ describe("MessageHandler errors", () => {
     );
     expect(mockSendMessage).toHaveBeenCalledWith(
       "ch-1",
-      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       "エラーが発生しました。しばらくしてからお試しください。",
     );
   });

--- a/src/bot/utils/message-formatter.test.ts
+++ b/src/bot/utils/message-formatter.test.ts
@@ -168,7 +168,6 @@ describe("MessageFormatter.formatPhaseStatus", () => {
   it("includes issue number and title", () => {
     const issueInfo = createIssueInfo({ number: 99, title: "New Feature" });
     const result = MessageFormatter.formatPhaseStatus("init", issueInfo);
-    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
     expect(result).toBe("Issue #99: New Feature の開発を開始します");
   });
 });
@@ -181,7 +180,6 @@ describe("MessageFormatter.formatError", () => {
 
   it("includes reset guidance", () => {
     const result = MessageFormatter.formatError("Error", "planned");
-    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
     expect(result).toContain("/resetでやり直せます");
   });
 
@@ -236,7 +234,6 @@ describe("MessageFormatter.formatPhaseResult", () => {
 
   it("includes next step for non-completed phases", () => {
     const result = MessageFormatter.formatPhaseResult("init", "done");
-    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
     expect(result.some((r) => r.includes("計画を作成します..."))).toBe(true);
   });
 
@@ -255,11 +252,8 @@ describe("MessageFormatter.formatPhaseResult", () => {
   });
 
   it.each([
-    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
     ["planned", "開発を開始します..."],
-    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
     ["developed", "テストを実行します..."],
-    // biome-ignore lint/security/noSecrets: false positive on Japanese test strings
     ["tested", "コミットを作成します..."],
   ] as [
     Phase,

--- a/src/shared/utils/format.test.ts
+++ b/src/shared/utils/format.test.ts
@@ -3,57 +3,48 @@ import { DISCORD_MAX_LENGTH } from "@/shared/utils/constants";
 import { formatForDiscord } from "@/shared/utils/format";
 
 describe("formatForDiscord", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空文字列はそのまま返る", () => {
+  it("空文字列はそのまま返る", () => {
     expect(formatForDiscord("")).toBe("");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "制限内のテキストはそのまま返る", () => {
+  it("制限内のテキストはそのまま返る", () => {
     const text = "short message";
     expect(formatForDiscord(text)).toBe(text);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "ちょうど制限バイトのテキストはそのまま返る", () => {
+  it("ちょうど制限バイトのテキストはそのまま返る", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH);
     expect(formatForDiscord(text)).toBe(text);
   });
 });
 
 describe("formatForDiscord: 切り詰め", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "制限超過時は切り詰めて省略通知を付与する", () => {
+  it("制限超過時は切り詰めて省略通知を付与する", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH + 100);
     const result = formatForDiscord(text);
-    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result).toContain("... (続きは省略されました)");
     expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
       DISCORD_MAX_LENGTH,
     );
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "日本語テキストが制限超過時にバイトベースで切り詰められる", () => {
+  it("日本語テキストが制限超過時にバイトベースで切り詰められる", () => {
     // 日本語1文字 = UTF-8で3バイト
     // 2000 / 3 ≈ 666文字 + 通知文で制限超過
     const text = "あ".repeat(700);
     const result = formatForDiscord(text);
-    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result).toContain("... (続きは省略されました)");
     expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
       DISCORD_MAX_LENGTH,
     );
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "1バイトだけ制限を超えるテキストを切り詰める", () => {
+  it("1バイトだけ制限を超えるテキストを切り詰める", () => {
     const text = "a".repeat(DISCORD_MAX_LENGTH + 1);
     const result = formatForDiscord(text);
     expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(
       DISCORD_MAX_LENGTH,
     );
-    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result).toContain("... (続きは省略されました)");
   });
 });

--- a/src/shared/utils/truncate.test.ts
+++ b/src/shared/utils/truncate.test.ts
@@ -2,15 +2,13 @@ import { describe, expect, it } from "vitest";
 import { truncateToBytes } from "./truncate";
 
 describe("truncateToBytes", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "制限内のテキストはそのまま返る", () => {
+  it("制限内のテキストはそのまま返る", () => {
     const result = truncateToBytes("hello", 100);
     expect(result.text).toBe("hello");
     expect(result.wasTruncated).toBe(false);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "制限超過テキストは切り詰められる", () => {
+  it("制限超過テキストは切り詰められる", () => {
     const text = "a".repeat(1000);
     const result = truncateToBytes(text, 100);
     expect(result.wasTruncated).toBe(true);
@@ -18,8 +16,7 @@ describe("truncateToBytes", () => {
     expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "境界値: ちょうど制限のテキストは切り詰められない", () => {
+  it("境界値: ちょうど制限のテキストは切り詰められない", () => {
     const text = "あいうえお";
     const exactBytes = Buffer.byteLength(text, "utf-8");
     const result = truncateToBytes(text, exactBytes);
@@ -27,15 +24,13 @@ describe("truncateToBytes", () => {
     expect(result.wasTruncated).toBe(false);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "空文字列入力を処理する", () => {
+  it("空文字列入力を処理する", () => {
     const result = truncateToBytes("", 100);
     expect(result.text).toBe("");
     expect(result.wasTruncated).toBe(false);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "マルチバイト文字が途中で分割されない", () => {
+  it("マルチバイト文字が途中で分割されない", () => {
     const text = "あいうえおかきくけこ";
     const result = truncateToBytes(text, 20);
     expect(result.wasTruncated).toBe(true);
@@ -46,16 +41,12 @@ describe("truncateToBytes", () => {
   });
 });
 
-// biome-ignore lint/security/noSecrets: describe block name, not a secret
 describe("truncateToBytes: カスタム通知文", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "カスタム通知文を使用できる", () => {
+  it("カスタム通知文を使用できる", () => {
     const text = "a".repeat(1000);
-    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     const notice = "\n\n... (続きは省略されました)";
     const result = truncateToBytes(text, 100, notice);
     expect(result.wasTruncated).toBe(true);
-    // biome-ignore lint/security/noSecrets: static Japanese notice text, not a secret
     expect(result.text).toContain("続きは省略されました)");
     expect(result.text).not.toContain("... (truncated)");
     expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
@@ -63,8 +54,7 @@ describe("truncateToBytes: カスタム通知文", () => {
 });
 
 describe("truncateToBytes: 境界値", () => {
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "1バイトだけ制限を超えるテキストを切り詰める", () => {
+  it("1バイトだけ制限を超えるテキストを切り詰める", () => {
     const text = "a".repeat(101);
     const result = truncateToBytes(text, 100);
     expect(result.wasTruncated).toBe(true);
@@ -72,8 +62,7 @@ describe("truncateToBytes: 境界値", () => {
     expect(result.text).toContain("... (truncated)");
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "maxBytesが通知文のバイト長と等しい場合、本文は空になる", () => {
+  it("maxBytesが通知文のバイト長と等しい場合、本文は空になる", () => {
     const notice = "\n\n... (truncated)";
     const noticeBytes = Buffer.byteLength(notice, "utf-8");
     const text = "a".repeat(noticeBytes + 10);
@@ -83,8 +72,7 @@ describe("truncateToBytes: 境界値", () => {
     expect(Buffer.byteLength(result.text, "utf-8")).toBe(noticeBytes);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "通知文のバイト長がmaxBytesを超える場合、通知文をmaxBytesに切り詰める", () => {
+  it("通知文のバイト長がmaxBytesを超える場合、通知文をmaxBytesに切り詰める", () => {
     const text = "a".repeat(200);
     const longNotice = "X".repeat(200);
     const result = truncateToBytes(text, 100, longNotice);
@@ -92,8 +80,7 @@ describe("truncateToBytes: 境界値", () => {
     expect(Buffer.byteLength(result.text, "utf-8")).toBeLessThanOrEqual(100);
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "ASCIIとマルチバイト混在テキストの切り詰め境界で文字が分割されない", () => {
+  it("ASCIIとマルチバイト混在テキストの切り詰め境界で文字が分割されない", () => {
     const text = "aあaあaあaあaあ";
     const shortNotice = "…";
     const result = truncateToBytes(text, 10, shortNotice);
@@ -105,8 +92,7 @@ describe("truncateToBytes: 境界値", () => {
     }
   });
 
-  it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "maxBytesが0の場合、結果は空文字列になる", () => {
+  it("maxBytesが0の場合、結果は空文字列になる", () => {
     const text = "hello";
     const result = truncateToBytes(text, 0);
     expect(result.wasTruncated).toBe(true);

--- a/src/shared/utils/validation.test.ts
+++ b/src/shared/utils/validation.test.ts
@@ -5,7 +5,6 @@ import {
   isPositiveInt,
 } from "@/shared/utils/validation";
 
-// biome-ignore lint/security/noSecrets: function name "isNonEmptyString" is not a secret
 describe("isNonEmptyString", () => {
   it("returns true for a normal string", () => {
     expect(isNonEmptyString("hello")).toBe(true);


### PR DESCRIPTION
# チケット

close #15

# 概要

Discord Botに開発ワークフローを管理するdevelopコマンド群を追加しました。
Issue単位でinit → plan → develop → test → commit → prの一連の流れをBot上で実行できるようにします。

### 追加したコマンド
- `/init` - Issue情報を取得し、ワークスペースを初期化
- `/plan` - AIに実行計画を立案させる
- `/develop` - AIにコードを実装させる
- `/test` - AIにテストを作成させる
- `/commit` - AIにコミットを作成させる
- `/pr` - AIにPRを作成させる
- `/reset` - ワークスペースをリセット

### その他の変更
- `biome.json` にテストファイル向けのoverridesを追加（`noSecrets`, `noExcessiveLinesPerFunction`を無効化）
- テストファイルから不要になった `biome-ignore` コメントを一括削除
- `BotConfig` に `github` / `workspace` 設定を追加
- `bootstrap.ts` でdevelopコマンド群をDIコンテナに組み込み

# その他

resolves #15